### PR TITLE
Add proveedor CRUD and menu entry

### DIFF
--- a/controladores/proveedor.php
+++ b/controladores/proveedor.php
@@ -1,0 +1,62 @@
+<?php
+require_once '../conexion/db.php';
+
+$base_datos = new DB();
+$db = $base_datos->conectar();
+
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $query = $db->prepare(
+        "INSERT INTO proveedor (razon_social, ruc, direccion, id_ciudad, estado) " .
+        "VALUES (:razon_social, :ruc, :direccion, :id_ciudad, :estado)"
+    );
+    $query->execute($datos);
+}
+
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $query = $db->prepare(
+        "UPDATE proveedor SET razon_social = :razon_social, ruc = :ruc, " .
+        "direccion = :direccion, id_ciudad = :id_ciudad, estado = :estado " .
+        "WHERE id_proveedor = :id_proveedor"
+    );
+    $query->execute($datos);
+}
+
+if (isset($_POST['eliminar'])) {
+    $query = $db->prepare("DELETE FROM proveedor WHERE id_proveedor = :id");
+    $query->execute(['id' => $_POST['eliminar']]);
+}
+
+if (isset($_POST['leer'])) {
+    $query = $db->prepare(
+        "SELECT p.id_proveedor, p.razon_social, p.ruc, p.direccion, p.estado, " .
+        "c.descripcion AS ciudad " .
+        "FROM proveedor p LEFT JOIN ciudad c ON p.id_ciudad = c.id_ciudad " .
+        "ORDER BY p.id_proveedor DESC"
+    );
+    $query->execute();
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+if (isset($_POST['leer_descripcion'])) {
+    $filtro = '%' . $_POST['leer_descripcion'] . '%';
+    $query = $db->prepare(
+        "SELECT p.id_proveedor, p.razon_social, p.ruc, p.direccion, p.estado, " .
+        "c.descripcion AS ciudad " .
+        "FROM proveedor p LEFT JOIN ciudad c ON p.id_ciudad = c.id_ciudad " .
+        "WHERE CONCAT(p.id_proveedor, p.razon_social, p.ruc, p.direccion, c.descripcion, p.estado) LIKE :filtro " .
+        "ORDER BY p.id_proveedor DESC"
+    );
+    $query->execute(['filtro' => $filtro]);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+if (isset($_POST['leer_id'])) {
+    $query = $db->prepare(
+        "SELECT id_proveedor, razon_social, ruc, direccion, id_ciudad, estado " .
+        "FROM proveedor WHERE id_proveedor = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}

--- a/menu.php
+++ b/menu.php
@@ -324,6 +324,12 @@
   </a>
 </li>
 <li class="nav-item">
+  <a href="#" class="nav-link" onclick="mostrarListarProveedor(); return false;">
+    <i class="nav-icon bi bi-circle"></i>
+    <p>Proveedores</p>
+  </a>
+</li>
+<li class="nav-item">
   <a href="#" class="nav-link" onclick="mostrarListarEbooks(); return false;">
     <i class="nav-icon bi bi-circle"></i>
     <p>Ebooks</p>
@@ -662,6 +668,7 @@
     <script src="vistas/compras.js"></script>
     <script src="vistas/categorias.js"></script>
     <script src="vistas/resenas.js"></script>
+    <script src="vistas/proveedor.js"></script>
     <!--end::Script-->
   </body>
   <!--end::Body-->

--- a/paginas/referenciales/proveedor/agregar.php
+++ b/paginas/referenciales/proveedor/agregar.php
@@ -1,0 +1,43 @@
+<div class="container mt-4">
+    <input type="hidden" id="id_proveedor" value="0">
+    <div class="card shadow rounded-4">
+        <div class="card-header bg-success text-white rounded-top-4">
+            <h4 class="mb-0">Agregar / Editar Proveedor</h4>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="razon_txt" class="form-label">Razón Social</label>
+                    <input type="text" id="razon_txt" class="form-control" placeholder="Nombre o empresa">
+                </div>
+                <div class="col-md-6">
+                    <label for="ruc_txt" class="form-label">RUC</label>
+                    <input type="text" id="ruc_txt" class="form-control" placeholder="RUC">
+                </div>
+                <div class="col-md-6">
+                    <label for="direccion_txt" class="form-label">Dirección</label>
+                    <input type="text" id="direccion_txt" class="form-control" placeholder="Dirección">
+                </div>
+                <div class="col-md-6">
+                    <label for="ciudad_lst" class="form-label">Ciudad</label>
+                    <select id="ciudad_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-6">
+                    <label for="estado_lst" class="form-label">Estado</label>
+                    <select id="estado_lst" class="form-select">
+                        <option value="ACTIVO">ACTIVO</option>
+                        <option value="INACTIVO">INACTIVO</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+        <div class="card-footer text-end">
+            <button class="btn btn-success me-2" onclick="guardarProveedor(); return false;">
+                <i class="bi bi-save"></i> Guardar
+            </button>
+            <button class="btn btn-danger" onclick="mostrarListarProveedor(); return false;">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>

--- a/paginas/referenciales/proveedor/listar.php
+++ b/paginas/referenciales/proveedor/listar.php
@@ -1,0 +1,39 @@
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">📦 Listado de Proveedores</h4>
+        <button class="btn btn-primary" onclick="mostrarAgregarProveedor(); return false;">
+            <i class="bi bi-plus-circle"></i> Agregar
+        </button>
+    </div>
+    <div class="card shadow-sm rounded-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-8">
+                    <label for="b_proveedor" class="form-label">🔍 Buscador</label>
+                    <input type="text" id="b_proveedor" class="form-control" placeholder="Buscar proveedores...">
+                </div>
+                <div class="col-md-4">
+                    <button class="btn btn-secondary w-100" onclick="buscarProveedor(); return false;">
+                        <i class="bi bi-search"></i> Buscar
+                    </button>
+                </div>
+            </div>
+            <div class="table-responsive mt-4">
+                <table class="table table-bordered table-hover align-middle text-center">
+                    <thead class="table-light">
+                        <tr>
+                            <th>#</th>
+                            <th>Razón Social</th>
+                            <th>RUC</th>
+                            <th>Dirección</th>
+                            <th>Ciudad</th>
+                            <th>Estado</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="datos_tb"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/vistas/proveedor.js
+++ b/vistas/proveedor.js
@@ -1,0 +1,151 @@
+function mostrarListarProveedor(){
+    let contenido = dameContenido("paginas/referenciales/proveedor/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaProveedor();
+}
+
+function mostrarAgregarProveedor(callback = null){
+    let contenido = dameContenido("paginas/referenciales/proveedor/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaCiudad("#ciudad_lst");
+    if(callback){
+        setTimeout(callback,100);
+    }
+}
+
+function cargarListaCiudad(componente){
+    let datos = ejecutarAjax("controladores/ciudad.php","leer=1");
+    if(datos === "0"){
+        $(componente).html("<option value='0'>Selecciona una ciudad</option>");
+    }else{
+        let json = JSON.parse(datos);
+        $(componente).html("<option value='0'>Selecciona una ciudad</option>");
+        json.map(function(it){
+            $(componente).append(`<option value="${it.id_ciudad}">${it.descripcion}</option>`);
+        });
+    }
+}
+
+function guardarProveedor(){
+    if($("#razon_txt").val().trim().length===0){
+        alert("Debes ingresar la razón social");
+        return;
+    }
+    if($("#ruc_txt").val().trim().length===0){
+        alert("Debes ingresar el RUC");
+        return;
+    }
+    if($("#direccion_txt").val().trim().length===0){
+        alert("Debes ingresar la dirección");
+        return;
+    }
+    if($("#ciudad_lst").val()==="0"){
+        alert("Debes seleccionar la ciudad");
+        return;
+    }
+
+    let datos={
+        razon_social: $("#razon_txt").val(),
+        ruc: $("#ruc_txt").val(),
+        direccion: $("#direccion_txt").val(),
+        id_ciudad: $("#ciudad_lst").val(),
+        estado: $("#estado_lst").val()
+    };
+
+    if($("#id_proveedor").val()==="0"){
+        let res = ejecutarAjax("controladores/proveedor.php","guardar="+JSON.stringify(datos));
+        alert("Guardado correctamente");
+        mostrarListarProveedor();
+        limpiarProveedor();
+    }else{
+        datos = {...datos, id_proveedor: $("#id_proveedor").val()};
+        let res = ejecutarAjax("controladores/proveedor.php","actualizar="+JSON.stringify(datos));
+        alert("Actualizado correctamente");
+        mostrarListarProveedor();
+        limpiarProveedor();
+    }
+}
+
+function cargarTablaProveedor(){
+    let datos = ejecutarAjax("controladores/proveedor.php","leer=1");
+    if(datos === "0"){
+        $("#datos_tb").html("NO HAY REGISTROS");
+    }else{
+        $("#datos_tb").html("");
+        let json = JSON.parse(datos);
+        json.map(function(it){
+            $("#datos_tb").append(`
+                <tr>
+                    <td>${it.id_proveedor}</td>
+                    <td>${it.razon_social}</td>
+                    <td>${it.ruc}</td>
+                    <td>${it.direccion}</td>
+                    <td>${it.ciudad}</td>
+                    <td>${it.estado}</td>
+                    <td>
+                        <button class="btn btn-warning editar-proveedor">Editar</button>
+                        <button class="btn btn-danger eliminar-proveedor">Eliminar</button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+
+$(document).on("click",".editar-proveedor",function(){
+    let id=$(this).closest("tr").find("td:eq(0)").text();
+    mostrarAgregarProveedor(function(){
+        let datos=ejecutarAjax("controladores/proveedor.php","leer_id="+id);
+        let json=JSON.parse(datos);
+        $("#id_proveedor").val(json.id_proveedor);
+        $("#razon_txt").val(json.razon_social);
+        $("#ruc_txt").val(json.ruc);
+        $("#direccion_txt").val(json.direccion);
+        $("#ciudad_lst").val(json.id_ciudad);
+        $("#estado_lst").val(json.estado);
+    });
+});
+
+$(document).on("click",".eliminar-proveedor",function(){
+    let id=$(this).closest("tr").find("td:eq(0)").text();
+    let res=ejecutarAjax("controladores/proveedor.php","eliminar="+id);
+    alert("Eliminado correctamente");
+    cargarTablaProveedor();
+});
+
+$(document).on("keyup","#b_proveedor",function(){
+    buscarProveedor();
+});
+
+function buscarProveedor(){
+    let datos=ejecutarAjax("controladores/proveedor.php","leer_descripcion="+$("#b_proveedor").val());
+    if(datos === "0"){
+        $("#datos_tb").html("NO HAY REGISTROS");
+    }else{
+        $("#datos_tb").html("");
+        let json=JSON.parse(datos);
+        json.map(function(it){
+            $("#datos_tb").append(`
+                <tr>
+                    <td>${it.id_proveedor}</td>
+                    <td>${it.razon_social}</td>
+                    <td>${it.ruc}</td>
+                    <td>${it.direccion}</td>
+                    <td>${it.ciudad}</td>
+                    <td>${it.estado}</td>
+                    <td>
+                        <button class="btn btn-warning editar-proveedor">Editar</button>
+                        <button class="btn btn-danger eliminar-proveedor">Eliminar</button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+
+function limpiarProveedor(){
+    $("#id_proveedor").val("0");
+    $("#razon_txt").val("");
+    $("#ruc_txt").val("");
+    $("#direccion_txt").val("");
+    $("#ciudad_lst").val("0");
+    $("#estado_lst").val("ACTIVO");
+}


### PR DESCRIPTION
## Summary
- implement proveedor CRUD controller
- add proveedor listing and add pages
- create frontend logic for proveedores
- integrate proveedores into the menu and load JS

## Testing
- `php -l controladores/proveedor.php`
- `php -l paginas/referenciales/proveedor/agregar.php`
- `php -l paginas/referenciales/proveedor/listar.php`
- `php -l menu.php`


------
https://chatgpt.com/codex/tasks/task_e_688ac55292748325bc712c0424ac68fb