### PR TITLE
Add purchase budget module

### DIFF
--- a/controladores/presupuestos_compra.php
+++ b/controladores/presupuestos_compra.php
@@ -1,0 +1,73 @@
+<?php
+require_once '../conexion/db.php';
+
+// GUARDAR PRESUPUESTO
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "INSERT INTO presupuestos_compra (fecha, id_proveedor, total_estimado) VALUES (:fecha, :id_proveedor, :total_estimado)"
+    );
+    $query->execute($datos);
+}
+
+// ACTUALIZAR PRESUPUESTO
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "UPDATE presupuestos_compra SET fecha = :fecha, id_proveedor = :id_proveedor, total_estimado = :total_estimado WHERE id_presupuesto = :id_presupuesto"
+    );
+    $query->execute($datos);
+}
+
+// ELIMINAR PRESUPUESTO
+if (isset($_POST['eliminar'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("DELETE FROM presupuestos_compra WHERE id_presupuesto = :id");
+    $query->execute(["id" => $_POST['eliminar']]);
+}
+
+// LEER TODAS LOS PRESUPUESTOS
+if (isset($_POST['leer'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor ORDER BY p.id_presupuesto DESC"
+    );
+    $query->execute();
+    if ($query->rowCount()) {
+        echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "SELECT id_presupuesto, fecha, id_proveedor, total_estimado FROM presupuestos_compra WHERE id_presupuesto = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    if ($query->rowCount()) {
+        echo json_encode($query->fetch(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+
+// LEER POR DESCRIPCION
+if (isset($_POST['leer_descripcion'])) {
+    $f = '%' . $_POST['leer_descripcion'] . '%';
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE CONCAT(p.id_presupuesto, pr.razon_social) LIKE :filtro ORDER BY p.id_presupuesto DESC"
+    );
+    $query->execute(['filtro' => $f]);
+    if ($query->rowCount()) {
+        echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+?>

--- a/menu.php
+++ b/menu.php
@@ -355,6 +355,12 @@
   </a>
 </li>
 <li class="nav-item">
+  <a href="#" class="nav-link" onclick="mostrarListarPresupuestos(); return false;">
+    <i class="nav-icon bi bi-circle"></i>
+    <p>Presupuestos</p>
+  </a>
+</li>
+<li class="nav-item">
   <a href="#" class="nav-link" onclick="mostrarListarCategorias(); return false;">
     <i class="nav-icon bi bi-circle"></i>
     <p>Categorías</p>
@@ -680,6 +686,7 @@
     <script src="vistas/usuarioss.js"></script>
     <script src="vistas/ebooks.js"></script>
     <script src="vistas/compras.js"></script>
+    <script src="vistas/presupuestos_compra.js"></script>
     <script src="vistas/categorias.js"></script>
     <script src="vistas/resenas.js"></script>
     <script src="vistas/proveedor.js"></script>

--- a/paginas/referenciales/presupuestos_compra/agregar.php
+++ b/paginas/referenciales/presupuestos_compra/agregar.php
@@ -1,0 +1,32 @@
+<div class="container mt-4">
+    <input type="hidden" id="id_presupuesto" value="0">
+    <div class="card shadow rounded-4">
+        <div class="card-header bg-success text-white rounded-top-4">
+            <h4 class="mb-0">Agregar / Editar Presupuesto</h4>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="id_proveedor_lst" class="form-label">Proveedor</label>
+                    <select id="id_proveedor_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-6">
+                    <label for="fecha_txt" class="form-label">Fecha</label>
+                    <input type="date" id="fecha_txt" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="total_txt" class="form-label">Total Estimado</label>
+                    <input type="number" step="0.01" id="total_txt" class="form-control" placeholder="0.00">
+                </div>
+            </div>
+        </div>
+        <div class="card-footer text-end">
+            <button class="btn btn-success me-2" onclick="guardarPresupuesto(); return false;">
+                <i class="bi bi-save"></i> Guardar
+            </button>
+            <button class="btn btn-danger" onclick="mostrarListarPresupuestos(); return false;">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>

--- a/paginas/referenciales/presupuestos_compra/listar.php
+++ b/paginas/referenciales/presupuestos_compra/listar.php
@@ -1,0 +1,39 @@
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">Listado de Presupuestos</h4>
+        <button class="btn btn-primary" onclick="mostrarAgregarPresupuesto(); return false;">
+            <i class="bi bi-plus-circle"></i> Agregar
+        </button>
+    </div>
+    <div class="card shadow-sm rounded-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-8">
+                    <label for="b_presupuesto" class="form-label">Buscador</label>
+                    <input type="text" id="b_presupuesto" class="form-control" placeholder="Buscar por proveedor...">
+                </div>
+                <div class="col-md-4">
+                    <button class="btn btn-secondary w-100" onclick="buscarPresupuesto(); return false;">
+                        <i class="bi bi-search"></i> Buscar
+                    </button>
+                </div>
+            </div>
+            <div class="table-responsive mt-4">
+                <table class="table table-bordered table-hover align-middle text-center">
+                    <thead class="table-light">
+                        <tr>
+                            <th>#</th>
+                            <th>Proveedor</th>
+                            <th>Fecha</th>
+                            <th>Total Estimado</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="datos_tb">
+                        <!-- Contenido dinámico -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/utcdp1.sql
+++ b/utcdp1.sql
@@ -245,6 +245,31 @@ INSERT INTO `productos` (`producto_id`, `nombre`, `descripcion`, `precio`, `tipo
 
 -- --------------------------------------------------------
 
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `presupuestos_compra`
+--
+CREATE TABLE `presupuestos_compra` (
+  `id_presupuesto` int(11) NOT NULL,
+  `fecha` date NOT NULL,
+  `id_proveedor` int(11) NOT NULL,
+  `total_estimado` decimal(10,2) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `detalle_presupuesto`
+--
+CREATE TABLE `detalle_presupuesto` (
+  `id_detalle` int(11) NOT NULL,
+  `id_presupuesto` int(11) NOT NULL,
+  `id_producto` int(11) NOT NULL,
+  `cantidad` int(11) NOT NULL,
+  `precio_unitario` decimal(10,2) NOT NULL,
+  `subtotal` decimal(10,2) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+
 --
 -- Estructura de tabla para la tabla `resenas`
 --
@@ -366,6 +391,16 @@ ALTER TABLE `producto`
 ALTER TABLE `productos`
   ADD PRIMARY KEY (`producto_id`);
 
+-- Indices de la tabla `presupuestos_compra`
+ALTER TABLE `presupuestos_compra`
+  ADD PRIMARY KEY (`id_presupuesto`),
+  ADD KEY `id_proveedor` (`id_proveedor`);
+
+-- Indices de la tabla `detalle_presupuesto`
+ALTER TABLE `detalle_presupuesto`
+  ADD PRIMARY KEY (`id_detalle`),
+  ADD KEY `id_presupuesto` (`id_presupuesto`),
+  ADD KEY `id_producto` (`id_producto`);
 --
 -- Indices de la tabla `proveedor`
 --
@@ -463,6 +498,13 @@ ALTER TABLE `proveedor`
 ALTER TABLE `cliente`
   MODIFY `id_cliente` int(11) NOT NULL AUTO_INCREMENT;
 
+-- AUTO_INCREMENT de la tabla `presupuestos_compra`
+ALTER TABLE `presupuestos_compra`
+  MODIFY `id_presupuesto` int(11) NOT NULL AUTO_INCREMENT;
+
+-- AUTO_INCREMENT de la tabla `detalle_presupuesto`
+ALTER TABLE `detalle_presupuesto`
+  MODIFY `id_detalle` int(11) NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT de la tabla `resenas`
 --
@@ -497,6 +539,14 @@ ALTER TABLE `ciudad`
 ALTER TABLE `compras`
   ADD CONSTRAINT `compras_ibfk_1` FOREIGN KEY (`usuario_id`) REFERENCES `usuarioss` (`usuario_id`);
 
+-- Filtros para la tabla `presupuestos_compra`
+ALTER TABLE `presupuestos_compra`
+  ADD CONSTRAINT `presupuestos_compra_ibfk_1` FOREIGN KEY (`id_proveedor`) REFERENCES `proveedor` (`id_proveedor`);
+
+-- Filtros para la tabla `detalle_presupuesto`
+ALTER TABLE `detalle_presupuesto`
+  ADD CONSTRAINT `detalle_presupuesto_ibfk_1` FOREIGN KEY (`id_presupuesto`) REFERENCES `presupuestos_compra` (`id_presupuesto`),
+  ADD CONSTRAINT `detalle_presupuesto_ibfk_2` FOREIGN KEY (`id_producto`) REFERENCES `productos` (`producto_id`);
 --
 -- Filtros para la tabla `resenas`
 --

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -1,0 +1,129 @@
+function mostrarListarPresupuestos(){
+    let contenido = dameContenido("paginas/referenciales/presupuestos_compra/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaPresupuesto();
+}
+
+function mostrarAgregarPresupuesto(){
+    let contenido = dameContenido("paginas/referenciales/presupuestos_compra/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaProveedores();
+    limpiarPresupuesto();
+}
+
+function cargarListaProveedores(){
+    let datos = ejecutarAjax("controladores/proveedor.php","leer=1");
+    if(datos !== "0"){
+        let json = JSON.parse(datos);
+        let select = $("#id_proveedor_lst");
+        select.html('<option value="">-- Seleccione un proveedor --</option>');
+        json.map(function(p){
+            select.append(`<option value="${p.id_proveedor}">${p.razon_social}</option>`);
+        });
+    }
+}
+
+function guardarPresupuesto(){
+    if($("#id_proveedor_lst").val() === "" || $("#id_proveedor_lst").val() === null){
+        alert("Debe seleccionar un proveedor");
+        return;
+    }
+    if($("#fecha_txt").val().trim().length===0){
+        alert("Debe ingresar la fecha");
+        return;
+    }
+    if($("#total_txt").val().trim().length===0){
+        alert("Debe ingresar el total estimado");
+        return;
+    }
+    let datos = {
+        id_proveedor: $("#id_proveedor_lst").val(),
+        fecha: $("#fecha_txt").val(),
+        total_estimado: $("#total_txt").val()
+    };
+    if($("#id_presupuesto").val() === "0"){
+        ejecutarAjax("controladores/presupuestos_compra.php","guardar="+JSON.stringify(datos));
+        alert("Guardado correctamente");
+    }else{
+        datos = {...datos, id_presupuesto: $("#id_presupuesto").val()};
+        ejecutarAjax("controladores/presupuestos_compra.php","actualizar="+JSON.stringify(datos));
+        alert("Actualizado correctamente");
+    }
+    mostrarListarPresupuestos();
+    limpiarPresupuesto();
+}
+
+function cargarTablaPresupuesto(){
+    let datos = ejecutarAjax("controladores/presupuestos_compra.php","leer=1");
+    if(datos === "0"){
+        $("#datos_tb").html("NO HAY REGISTROS");
+    }else{
+        $("#datos_tb").html("");
+        let json = JSON.parse(datos);
+        json.map(function(it){
+            $("#datos_tb").append(`
+                <tr>
+                    <td>${it.id_presupuesto}</td>
+                    <td>${it.proveedor}</td>
+                    <td>${it.fecha}</td>
+                    <td>${it.total_estimado}</td>
+                    <td>
+                        <button class="btn btn-warning editar-presupuesto">Editar</button>
+                        <button class="btn btn-danger eliminar-presupuesto">Eliminar</button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+
+$(document).on("click",".editar-presupuesto",function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    mostrarAgregarPresupuesto();
+    let datos = ejecutarAjax("controladores/presupuestos_compra.php","leer_id="+id);
+    let json = JSON.parse(datos);
+    $("#id_presupuesto").val(json.id_presupuesto);
+    $("#id_proveedor_lst").val(json.id_proveedor);
+    $("#fecha_txt").val(json.fecha);
+    $("#total_txt").val(json.total_estimado);
+});
+
+$(document).on("click",".eliminar-presupuesto",function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    ejecutarAjax("controladores/presupuestos_compra.php","eliminar="+id);
+    alert("Eliminado");
+    cargarTablaPresupuesto();
+});
+
+$(document).on("keyup","#b_presupuesto",function(){
+    buscarPresupuesto();
+});
+
+function buscarPresupuesto(){
+    let datos = ejecutarAjax("controladores/presupuestos_compra.php","leer_descripcion="+$("#b_presupuesto").val());
+    if(datos === "0"){
+        $("#datos_tb").html("NO HAY REGISTROS");
+    }else{
+        $("#datos_tb").html("");
+        let json = JSON.parse(datos);
+        json.map(function(it){
+            $("#datos_tb").append(`
+                <tr>
+                    <td>${it.id_presupuesto}</td>
+                    <td>${it.proveedor}</td>
+                    <td>${it.fecha}</td>
+                    <td>${it.total_estimado}</td>
+                    <td>
+                        <button class="btn btn-warning editar-presupuesto">Editar</button>
+                        <button class="btn btn-danger eliminar-presupuesto">Eliminar</button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+
+function limpiarPresupuesto(){
+    $("#id_presupuesto").val("0");
+    $("#id_proveedor_lst").val("");
+    $("#fecha_txt").val("");
+    $("#total_txt").val("");
+}


### PR DESCRIPTION
## Summary
- add new SQL tables `presupuestos_compra` and `detalle_presupuesto`
- add PHP controller for presupuestos
- create budget pages and JS
- update menu to include budgets module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688beb3c687083258222f25cd1b0dcc0