### PR TITLE
Agregar módulo Detalle Presupuesto

### DIFF
--- a/controladores/detalle_presupuesto.php
+++ b/controladores/detalle_presupuesto.php
@@ -1,0 +1,71 @@
+<?php
+require_once '../conexion/db.php';
+
+$db = new DB();
+$cn = $db->conectar();
+
+// GUARDAR DETALLE
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $query = $cn->prepare(
+        "INSERT INTO detalle_presupuesto (id_presupuesto, id_producto, cantidad, precio_unitario, subtotal) " .
+        "VALUES (:id_presupuesto, :id_producto, :cantidad, :precio_unitario, :subtotal)"
+    );
+    $query->execute($datos);
+}
+
+// ACTUALIZAR DETALLE
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $query = $cn->prepare(
+        "UPDATE detalle_presupuesto SET id_presupuesto = :id_presupuesto, id_producto = :id_producto, " .
+        "cantidad = :cantidad, precio_unitario = :precio_unitario, subtotal = :subtotal " .
+        "WHERE id_detalle = :id_detalle"
+    );
+    $query->execute($datos);
+}
+
+// ELIMINAR DETALLE
+if (isset($_POST['eliminar'])) {
+    $query = $cn->prepare("DELETE FROM detalle_presupuesto WHERE id_detalle = :id");
+    $query->execute(['id' => $_POST['eliminar']]);
+}
+
+// LISTAR DETALLES
+if (isset($_POST['leer'])) {
+    $query = $cn->prepare(
+        "SELECT d.id_detalle, d.id_presupuesto, d.id_producto, p.nombre AS producto, " .
+        "d.cantidad, d.precio_unitario, d.subtotal " .
+        "FROM detalle_presupuesto d " .
+        "LEFT JOIN productos p ON d.id_producto = p.producto_id " .
+        "ORDER BY d.id_detalle DESC"
+    );
+    $query->execute();
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $query = $cn->prepare(
+        "SELECT id_detalle, id_presupuesto, id_producto, cantidad, precio_unitario, subtotal " .
+        "FROM detalle_presupuesto WHERE id_detalle = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}
+
+// BUSCAR
+if (isset($_POST['leer_descripcion'])) {
+    $filtro = '%' . $_POST['leer_descripcion'] . '%';
+    $query = $cn->prepare(
+        "SELECT d.id_detalle, d.id_presupuesto, d.id_producto, p.nombre AS producto, " .
+        "d.cantidad, d.precio_unitario, d.subtotal " .
+        "FROM detalle_presupuesto d " .
+        "LEFT JOIN productos p ON d.id_producto = p.producto_id " .
+        "WHERE CONCAT(d.id_detalle, p.nombre, d.id_presupuesto) LIKE :filtro " .
+        "ORDER BY d.id_detalle DESC"
+    );
+    $query->execute(['filtro' => $filtro]);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+?>

--- a/menu.php
+++ b/menu.php
@@ -361,6 +361,12 @@
   </a>
 </li>
 <li class="nav-item">
+  <a href="#" class="nav-link" onclick="mostrarListarDetallePresupuesto(); return false;">
+    <i class="nav-icon bi bi-circle"></i>
+    <p>Detalle Presupuesto</p>
+  </a>
+</li>
+<li class="nav-item">
   <a href="#" class="nav-link" onclick="mostrarListarCategorias(); return false;">
     <i class="nav-icon bi bi-circle"></i>
     <p>Categorías</p>
@@ -687,6 +693,7 @@
     <script src="vistas/ebooks.js"></script>
     <script src="vistas/compras.js"></script>
     <script src="vistas/presupuestos_compra.js"></script>
+    <script src="vistas/detalle_presupuesto.js"></script>
     <script src="vistas/categorias.js"></script>
     <script src="vistas/resenas.js"></script>
     <script src="vistas/proveedor.js"></script>

--- a/paginas/referenciales/detalle_presupuesto/agregar.php
+++ b/paginas/referenciales/detalle_presupuesto/agregar.php
@@ -1,0 +1,47 @@
+<div class="container mt-4">
+    <input type="hidden" id="id_detalle" value="0">
+    <div class="card shadow rounded-4">
+        <div class="card-header bg-warning text-dark rounded-top-4">
+            <h4 class="mb-0">Agregar / Editar Detalle de Presupuesto</h4>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="id_presupuesto_lst" class="form-label">Presupuesto</label>
+                    <select id="id_presupuesto_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-6">
+                    <label for="id_producto_lst" class="form-label">Producto</label>
+                    <select id="id_producto_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-6">
+                    <label for="cantidad_txt" class="form-label">Cantidad</label>
+                    <input type="number" id="cantidad_txt" class="form-control" min="0">
+                </div>
+                <div class="col-md-6">
+                    <label for="precio_unitario_txt" class="form-label">Precio Unitario</label>
+                    <input type="number" step="0.01" id="precio_unitario_txt" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="subtotal_txt" class="form-label">Subtotal</label>
+                    <input type="number" step="0.01" id="subtotal_txt" class="form-control" readonly>
+                </div>
+            </div>
+        </div>
+        <div class="card-footer text-end">
+            <button class="btn btn-success me-2" onclick="guardarDetallePresupuesto(); return false;">
+                <i class="bi bi-save"></i> Guardar
+            </button>
+            <button class="btn btn-danger" onclick="mostrarListarDetallePresupuesto(); return false;">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>
+<script>
+$(document).on('input','#cantidad_txt,#precio_unitario_txt',function(){
+    const cant = parseFloat($('#cantidad_txt').val()) || 0;
+    const precio = parseFloat($('#precio_unitario_txt').val()) || 0;
+    $('#subtotal_txt').val((cant * precio).toFixed(2));
+});
+</script>

--- a/paginas/referenciales/detalle_presupuesto/listar.php
+++ b/paginas/referenciales/detalle_presupuesto/listar.php
@@ -1,0 +1,41 @@
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">Listado Detalle Presupuesto</h4>
+        <button class="btn btn-primary" onclick="mostrarAgregarDetallePresupuesto(); return false;">
+            <i class="bi bi-plus-circle"></i> Agregar
+        </button>
+    </div>
+    <div class="card shadow-sm rounded-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-8">
+                    <label for="b_detalle_presupuesto" class="form-label">Buscador</label>
+                    <input type="text" id="b_detalle_presupuesto" class="form-control" placeholder="Buscar...">
+                </div>
+                <div class="col-md-4">
+                    <button class="btn btn-secondary w-100" onclick="buscarDetallePresupuesto(); return false;">
+                        <i class="bi bi-search"></i> Buscar
+                    </button>
+                </div>
+            </div>
+            <div class="table-responsive mt-4">
+                <table class="table table-bordered table-hover align-middle text-center">
+                    <thead class="table-light">
+                        <tr>
+                            <th>#</th>
+                            <th>Presupuesto</th>
+                            <th>Producto</th>
+                            <th>Cantidad</th>
+                            <th>Precio Unitario</th>
+                            <th>Subtotal</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="datos_tb">
+                        <!-- datos -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/vistas/detalle_presupuesto.js
+++ b/vistas/detalle_presupuesto.js
@@ -1,0 +1,146 @@
+function mostrarListarDetallePresupuesto(){
+    let contenido = dameContenido("paginas/referenciales/detalle_presupuesto/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaDetallePresupuesto();
+}
+
+function mostrarAgregarDetallePresupuesto(){
+    let contenido = dameContenido("paginas/referenciales/detalle_presupuesto/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaPresupuestos();
+    cargarListaProductos();
+    limpiarDetallePresupuesto();
+}
+
+function cargarListaPresupuestos(){
+    let datos = ejecutarAjax("controladores/presupuestos_compra.php", "leer=1");
+    if(datos !== "0"){
+        let json = JSON.parse(datos);
+        let select = $("#id_presupuesto_lst");
+        select.html('<option value="">-- Seleccione un presupuesto --</option>');
+        json.map(function(p){
+            select.append(`<option value="${p.id_presupuesto}">${p.id_presupuesto} - ${p.proveedor}</option>`);
+        });
+    }
+}
+
+function cargarListaProductos(){
+    let datos = ejecutarAjax("controladores/productos.php", "leer=1");
+    if(datos !== "0"){
+        let json = JSON.parse(datos);
+        let select = $("#id_producto_lst");
+        select.html('<option value="">-- Seleccione un producto --</option>');
+        json.map(function(pr){
+            select.append(`<option value="${pr.producto_id}">${pr.nombre}</option>`);
+        });
+    }
+}
+
+function guardarDetallePresupuesto(){
+    if($("#id_presupuesto_lst").val() === ""){ alert("Debe seleccionar un presupuesto"); return; }
+    if($("#id_producto_lst").val() === ""){ alert("Debe seleccionar un producto"); return; }
+    if($("#cantidad_txt").val().trim().length===0){ alert("Debe ingresar la cantidad"); return; }
+    if($("#precio_unitario_txt").val().trim().length===0){ alert("Debe ingresar el precio unitario"); return; }
+
+    let datos = {
+        id_presupuesto: $("#id_presupuesto_lst").val(),
+        id_producto: $("#id_producto_lst").val(),
+        cantidad: $("#cantidad_txt").val(),
+        precio_unitario: $("#precio_unitario_txt").val(),
+        subtotal: $("#subtotal_txt").val()
+    };
+
+    if($("#id_detalle").val() === "0"){
+        ejecutarAjax("controladores/detalle_presupuesto.php", "guardar="+JSON.stringify(datos));
+        alert("Guardado correctamente");
+    }else{
+        datos = {...datos, id_detalle: $("#id_detalle").val()};
+        ejecutarAjax("controladores/detalle_presupuesto.php", "actualizar="+JSON.stringify(datos));
+        alert("Actualizado correctamente");
+    }
+    mostrarListarDetallePresupuesto();
+    limpiarDetallePresupuesto();
+}
+
+function cargarTablaDetallePresupuesto(){
+    let datos = ejecutarAjax("controladores/detalle_presupuesto.php", "leer=1");
+    if(datos === "0"){
+        $("#datos_tb").html("NO HAY REGISTROS");
+    }else{
+        $("#datos_tb").html("");
+        let json = JSON.parse(datos);
+        json.map(function(it){
+            $("#datos_tb").append(`
+                <tr>
+                    <td>${it.id_detalle}</td>
+                    <td>${it.id_presupuesto}</td>
+                    <td>${it.producto || it.id_producto}</td>
+                    <td>${it.cantidad}</td>
+                    <td>${it.precio_unitario}</td>
+                    <td>${it.subtotal}</td>
+                    <td>
+                        <button class="btn btn-warning editar-detalle">Editar</button>
+                        <button class="btn btn-danger eliminar-detalle">Eliminar</button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+
+$(document).on("click", ".editar-detalle", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    mostrarAgregarDetallePresupuesto();
+    let datos = ejecutarAjax("controladores/detalle_presupuesto.php", "leer_id="+id);
+    let json = JSON.parse(datos);
+    $("#id_detalle").val(json.id_detalle);
+    $("#id_presupuesto_lst").val(json.id_presupuesto);
+    $("#id_producto_lst").val(json.id_producto);
+    $("#cantidad_txt").val(json.cantidad);
+    $("#precio_unitario_txt").val(json.precio_unitario);
+    $("#subtotal_txt").val(json.subtotal);
+});
+
+$(document).on("click", ".eliminar-detalle", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    ejecutarAjax("controladores/detalle_presupuesto.php", "eliminar="+id);
+    alert("Eliminado");
+    cargarTablaDetallePresupuesto();
+});
+
+$(document).on("keyup", "#b_detalle_presupuesto", function(){
+    buscarDetallePresupuesto();
+});
+
+function buscarDetallePresupuesto(){
+    let datos = ejecutarAjax("controladores/detalle_presupuesto.php", "leer_descripcion="+$("#b_detalle_presupuesto").val());
+    if(datos === "0"){
+        $("#datos_tb").html("NO HAY REGISTROS");
+    }else{
+        $("#datos_tb").html("");
+        let json = JSON.parse(datos);
+        json.map(function(it){
+            $("#datos_tb").append(`
+                <tr>
+                    <td>${it.id_detalle}</td>
+                    <td>${it.id_presupuesto}</td>
+                    <td>${it.producto || it.id_producto}</td>
+                    <td>${it.cantidad}</td>
+                    <td>${it.precio_unitario}</td>
+                    <td>${it.subtotal}</td>
+                    <td>
+                        <button class="btn btn-warning editar-detalle">Editar</button>
+                        <button class="btn btn-danger eliminar-detalle">Eliminar</button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+
+function limpiarDetallePresupuesto(){
+    $("#id_detalle").val("0");
+    $("#id_presupuesto_lst").val("");
+    $("#id_producto_lst").val("");
+    $("#cantidad_txt").val("");
+    $("#precio_unitario_txt").val("");
+    $("#subtotal_txt").val("");
+}


### PR DESCRIPTION
## Resumen
- crear controlador `detalle_presupuesto.php`
- crear vistas y scripts para gestionar detalles de presupuesto
- incluir el módulo en el menú y cargar su script

## Testing
- `php -l controladores/detalle_presupuesto.php`
- `php -l paginas/referenciales/detalle_presupuesto/agregar.php`
- `php -l paginas/referenciales/detalle_presupuesto/listar.php`
- `php -l menu.php`


------
https://chatgpt.com/codex/tasks/task_e_688bf071ec708325992634ad8e02ad03