### PR TITLE
Vincular detalle de presupuesto con presupuestos

### DIFF
--- a/controladores/detalle_presupuesto.php
+++ b/controladores/detalle_presupuesto.php
@@ -33,14 +33,19 @@ if (isset($_POST['eliminar'])) {
 
 // LISTAR DETALLES
 if (isset($_POST['leer'])) {
-    $query = $cn->prepare(
+    $sql =
         "SELECT d.id_detalle, d.id_presupuesto, d.id_producto, p.nombre AS producto, " .
         "d.cantidad, d.precio_unitario, d.subtotal " .
         "FROM detalle_presupuesto d " .
-        "LEFT JOIN productos p ON d.id_producto = p.producto_id " .
-        "ORDER BY d.id_detalle DESC"
-    );
-    $query->execute();
+        "LEFT JOIN productos p ON d.id_producto = p.producto_id";
+    $params = [];
+    if (!empty($_POST['id_presupuesto'])) {
+        $sql .= " WHERE d.id_presupuesto = :id_presupuesto";
+        $params['id_presupuesto'] = $_POST['id_presupuesto'];
+    }
+    $sql .= " ORDER BY d.id_detalle DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
     echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
 
@@ -57,15 +62,20 @@ if (isset($_POST['leer_id'])) {
 // BUSCAR
 if (isset($_POST['leer_descripcion'])) {
     $filtro = '%' . $_POST['leer_descripcion'] . '%';
-    $query = $cn->prepare(
+    $sql =
         "SELECT d.id_detalle, d.id_presupuesto, d.id_producto, p.nombre AS producto, " .
         "d.cantidad, d.precio_unitario, d.subtotal " .
         "FROM detalle_presupuesto d " .
         "LEFT JOIN productos p ON d.id_producto = p.producto_id " .
-        "WHERE CONCAT(d.id_detalle, p.nombre, d.id_presupuesto) LIKE :filtro " .
-        "ORDER BY d.id_detalle DESC"
-    );
-    $query->execute(['filtro' => $filtro]);
+        "WHERE CONCAT(d.id_detalle, p.nombre, d.id_presupuesto) LIKE :filtro";
+    $params = ['filtro' => $filtro];
+    if (!empty($_POST['id_presupuesto'])) {
+        $sql .= " AND d.id_presupuesto = :id_presupuesto";
+        $params['id_presupuesto'] = $_POST['id_presupuesto'];
+    }
+    $sql .= " ORDER BY d.id_detalle DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
     echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
 ?>

--- a/paginas/referenciales/detalle_presupuesto/listar.php
+++ b/paginas/referenciales/detalle_presupuesto/listar.php
@@ -1,9 +1,14 @@
 <div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h4 class="mb-0">Listado Detalle Presupuesto</h4>
-        <button class="btn btn-primary" onclick="mostrarAgregarDetallePresupuesto(); return false;">
-            <i class="bi bi-plus-circle"></i> Agregar
-        </button>
+        <div>
+            <button class="btn btn-secondary me-2" onclick="mostrarListarPresupuestos(); return false;">
+                <i class="bi bi-arrow-left-circle"></i> Regresar
+            </button>
+            <button class="btn btn-primary" onclick="mostrarAgregarDetallePresupuesto(); return false;">
+                <i class="bi bi-plus-circle"></i> Agregar
+            </button>
+        </div>
     </div>
     <div class="card shadow-sm rounded-4">
         <div class="card-body">

--- a/vistas/detalle_presupuesto.js
+++ b/vistas/detalle_presupuesto.js
@@ -1,4 +1,9 @@
-function mostrarListarDetallePresupuesto(){
+const PRESUPUESTO_KEY = 'presupuestoDetalle';
+
+function mostrarListarDetallePresupuesto(id = null){
+    if(id !== null){
+        sessionStorage.setItem(PRESUPUESTO_KEY, id);
+    }
     let contenido = dameContenido("paginas/referenciales/detalle_presupuesto/listar.php");
     $("#contenido-principal").html(contenido);
     cargarTablaDetallePresupuesto();
@@ -21,6 +26,10 @@ function cargarListaPresupuestos(){
         json.map(function(p){
             select.append(`<option value="${p.id_presupuesto}">${p.id_presupuesto} - ${p.proveedor}</option>`);
         });
+        const actual = sessionStorage.getItem(PRESUPUESTO_KEY);
+        if(actual){
+            select.val(actual);
+        }
     }
 }
 
@@ -63,7 +72,12 @@ function guardarDetallePresupuesto(){
 }
 
 function cargarTablaDetallePresupuesto(){
-    let datos = ejecutarAjax("controladores/detalle_presupuesto.php", "leer=1");
+    let params = "leer=1";
+    const id = sessionStorage.getItem(PRESUPUESTO_KEY);
+    if(id){
+        params += "&id_presupuesto=" + id;
+    }
+    let datos = ejecutarAjax("controladores/detalle_presupuesto.php", params);
     if(datos === "0"){
         $("#datos_tb").html("NO HAY REGISTROS");
     }else{
@@ -112,7 +126,12 @@ $(document).on("keyup", "#b_detalle_presupuesto", function(){
 });
 
 function buscarDetallePresupuesto(){
-    let datos = ejecutarAjax("controladores/detalle_presupuesto.php", "leer_descripcion="+$("#b_detalle_presupuesto").val());
+    let params = "leer_descripcion="+$("#b_detalle_presupuesto").val();
+    const id = sessionStorage.getItem(PRESUPUESTO_KEY);
+    if(id){
+        params += "&id_presupuesto=" + id;
+    }
+    let datos = ejecutarAjax("controladores/detalle_presupuesto.php", params);
     if(datos === "0"){
         $("#datos_tb").html("NO HAY REGISTROS");
     }else{
@@ -138,7 +157,8 @@ function buscarDetallePresupuesto(){
 
 function limpiarDetallePresupuesto(){
     $("#id_detalle").val("0");
-    $("#id_presupuesto_lst").val("");
+    const id = sessionStorage.getItem(PRESUPUESTO_KEY) || "";
+    $("#id_presupuesto_lst").val(id);
     $("#id_producto_lst").val("");
     $("#cantidad_txt").val("");
     $("#precio_unitario_txt").val("");

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -1,4 +1,7 @@
+const PRESUPUESTO_KEY = 'presupuestoDetalle';
+
 function mostrarListarPresupuestos(){
+    sessionStorage.removeItem(PRESUPUESTO_KEY);
     let contenido = dameContenido("paginas/referenciales/presupuestos_compra/listar.php");
     $("#contenido-principal").html(contenido);
     cargarTablaPresupuesto();
@@ -68,6 +71,7 @@ function cargarTablaPresupuesto(){
                     <td>${it.fecha}</td>
                     <td>${it.total_estimado}</td>
                     <td>
+                        <button class="btn btn-info ver-detalle">Detalles</button>
                         <button class="btn btn-warning editar-presupuesto">Editar</button>
                         <button class="btn btn-danger eliminar-presupuesto">Eliminar</button>
                     </td>
@@ -85,6 +89,11 @@ $(document).on("click",".editar-presupuesto",function(){
     $("#id_proveedor_lst").val(json.id_proveedor);
     $("#fecha_txt").val(json.fecha);
     $("#total_txt").val(json.total_estimado);
+});
+
+$(document).on("click",".ver-detalle",function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    mostrarListarDetallePresupuesto(id);
 });
 
 $(document).on("click",".eliminar-presupuesto",function(){
@@ -113,6 +122,7 @@ function buscarPresupuesto(){
                     <td>${it.fecha}</td>
                     <td>${it.total_estimado}</td>
                     <td>
+                        <button class="btn btn-info ver-detalle">Detalles</button>
                         <button class="btn btn-warning editar-presupuesto">Editar</button>
                         <button class="btn btn-danger eliminar-presupuesto">Eliminar</button>
                     </td>


### PR DESCRIPTION
## Summary
- add filter support in `detalle_presupuesto.php`
- allow detail pages to remember selected presupuesto via sessionStorage
- show 'Detalles' button in presupuestos table
- include return button on detalle list

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688bf28a7a148325afedfaf14ebb6c18