### PR TITLE
Enable adding first budget item in one step

### DIFF
--- a/controladores/presupuestos_compra.php
+++ b/controladores/presupuestos_compra.php
@@ -5,10 +5,12 @@ require_once '../conexion/db.php';
 if (isset($_POST['guardar'])) {
     $datos = json_decode($_POST['guardar'], true);
     $db = new DB();
-    $query = $db->conectar()->prepare(
+    $cn = $db->conectar();
+    $query = $cn->prepare(
         "INSERT INTO presupuestos_compra (fecha, id_proveedor, total_estimado) VALUES (:fecha, :id_proveedor, :total_estimado)"
     );
     $query->execute($datos);
+    echo $cn->lastInsertId();
 }
 
 // ACTUALIZAR PRESUPUESTO

--- a/paginas/referenciales/presupuestos_compra/agregar.php
+++ b/paginas/referenciales/presupuestos_compra/agregar.php
@@ -18,6 +18,22 @@
                     <label for="total_txt" class="form-label">Total Estimado</label>
                     <input type="number" step="0.01" id="total_txt" class="form-control" placeholder="0.00">
                 </div>
+                <div class="col-md-6">
+                    <label for="id_producto_lst" class="form-label">Producto</label>
+                    <select id="id_producto_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-6">
+                    <label for="cantidad_txt" class="form-label">Cantidad</label>
+                    <input type="number" id="cantidad_txt" class="form-control" min="0">
+                </div>
+                <div class="col-md-6">
+                    <label for="precio_unitario_txt" class="form-label">Precio Unitario</label>
+                    <input type="number" step="0.01" id="precio_unitario_txt" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="subtotal_txt" class="form-label">Subtotal</label>
+                    <input type="number" step="0.01" id="subtotal_txt" class="form-control" readonly>
+                </div>
             </div>
         </div>
         <div class="card-footer text-end">
@@ -30,3 +46,10 @@
         </div>
     </div>
 </div>
+<script>
+$(document).on('input','#cantidad_txt,#precio_unitario_txt',function(){
+    const cant = parseFloat($('#cantidad_txt').val()) || 0;
+    const precio = parseFloat($('#precio_unitario_txt').val()) || 0;
+    $('#subtotal_txt').val((cant * precio).toFixed(2));
+});
+</script>

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -11,6 +11,7 @@ function mostrarAgregarPresupuesto(){
     let contenido = dameContenido("paginas/referenciales/presupuestos_compra/agregar.php");
     $("#contenido-principal").html(contenido);
     cargarListaProveedores();
+    cargarListaProductos();
     limpiarPresupuesto();
 }
 
@@ -22,6 +23,18 @@ function cargarListaProveedores(){
         select.html('<option value="">-- Seleccione un proveedor --</option>');
         json.map(function(p){
             select.append(`<option value="${p.id_proveedor}">${p.razon_social}</option>`);
+        });
+    }
+}
+
+function cargarListaProductos(){
+    let datos = ejecutarAjax("controladores/productos.php", "leer=1");
+    if(datos !== "0"){
+        let json = JSON.parse(datos);
+        let select = $("#id_producto_lst");
+        select.html('<option value="">-- Seleccione un producto --</option>');
+        json.map(function(p){
+            select.append(`<option value="${p.producto_id}">${p.nombre}</option>`);
         });
     }
 }
@@ -39,13 +52,24 @@ function guardarPresupuesto(){
         alert("Debe ingresar el total estimado");
         return;
     }
+    if($("#id_producto_lst").val() === ""){ alert("Debe seleccionar un producto"); return; }
+    if($("#cantidad_txt").val().trim().length===0){ alert("Debe ingresar la cantidad"); return; }
+    if($("#precio_unitario_txt").val().trim().length===0){ alert("Debe ingresar el precio unitario"); return; }
     let datos = {
         id_proveedor: $("#id_proveedor_lst").val(),
         fecha: $("#fecha_txt").val(),
         total_estimado: $("#total_txt").val()
     };
     if($("#id_presupuesto").val() === "0"){
-        ejecutarAjax("controladores/presupuestos_compra.php","guardar="+JSON.stringify(datos));
+        let id = ejecutarAjax("controladores/presupuestos_compra.php","guardar="+JSON.stringify(datos));
+        let detalle = {
+            id_presupuesto: id,
+            id_producto: $("#id_producto_lst").val(),
+            cantidad: $("#cantidad_txt").val(),
+            precio_unitario: $("#precio_unitario_txt").val(),
+            subtotal: $("#subtotal_txt").val()
+        };
+        ejecutarAjax("controladores/detalle_presupuesto.php","guardar="+JSON.stringify(detalle));
         alert("Guardado correctamente");
     }else{
         datos = {...datos, id_presupuesto: $("#id_presupuesto").val()};
@@ -136,4 +160,8 @@ function limpiarPresupuesto(){
     $("#id_proveedor_lst").val("");
     $("#fecha_txt").val("");
     $("#total_txt").val("");
+    $("#id_producto_lst").val("");
+    $("#cantidad_txt").val("");
+    $("#precio_unitario_txt").val("");
+    $("#subtotal_txt").val("");
 }


### PR DESCRIPTION
## Summary
- allow `presupuestos_compra.php` to return the inserted id
- extend `Agregar Presupuesto` view with product detail inputs
- add subtotal auto calculation
- update `presupuestos_compra.js` to save first detail when creating a budget

## Testing
- `php -l controladores/presupuestos_compra.php`
- `php -l paginas/referenciales/presupuestos_compra/agregar.php`


------
https://chatgpt.com/codex/tasks/task_e_688bf62119a48325b4e8b3544100c913