### PR TITLE
Improve budget printing

### DIFF
--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -174,7 +174,7 @@ function imprimirPresupuesto(id){
         <body>
             <h3 class="mb-4">Presupuesto #${presupuesto.id_presupuesto}</h3>
             <p><strong>Proveedor:</strong> ${presupuesto.proveedor || presupuesto.id_proveedor}</p>
-            <p><strong>Fecha:</strong> ${presupuesto.fecha}</p>
+            <p><strong>Fecha:</strong> ${formatearFechaDMA(presupuesto.fecha)}</p>
             <p><strong>Total Estimado:</strong> ${presupuesto.total_estimado}</p>
             <table class="table table-bordered">
                 <thead>

--- a/vistas/util.js
+++ b/vistas/util.js
@@ -180,6 +180,16 @@ function dameFechaFormateadaSQL(fecha) {
 
     return  fec[2] + "-" + fec[1] + "-" + fec[0];
 }
+
+// Convierte una fecha en formato ISO (aaaa-mm-dd) a dd/mm/aaaa
+function formatearFechaDMA(fechaStr){
+    var f = new Date(fechaStr);
+    if(isNaN(f)) return fechaStr;
+    var dia = ('0' + f.getDate()).slice(-2);
+    var mes = ('0' + (f.getMonth() + 1)).slice(-2);
+    var anio = f.getFullYear();
+    return dia + '/' + mes + '/' + anio;
+}
 function dameFechaFormateada(fecha) {
     var mes = fecha.getMonth() + 1;
     var dia = fecha.getDate() + 1;


### PR DESCRIPTION
## Summary
- print budget date in human-readable format
- add helper to format ISO dates as dd/mm/yyyy

## Testing
- `node --check vistas/presupuestos_compra.js`
- `node --check vistas/util.js`
- `php -l menu.php | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_688bfb4941248325b87034e2c259da4b