### PR TITLE
Fix editing presupuesto details

### DIFF
--- a/paginas/referenciales/presupuestos_compra/agregar.php
+++ b/paginas/referenciales/presupuestos_compra/agregar.php
@@ -1,5 +1,6 @@
 <div class="container mt-4">
     <input type="hidden" id="id_presupuesto" value="0">
+    <input type="hidden" id="id_detalle" value="0">
     <div class="card shadow rounded-4">
         <div class="card-header bg-success text-white rounded-top-4">
             <h4 class="mb-0">Agregar / Editar Presupuesto</h4>

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -71,6 +71,18 @@ function guardarPresupuesto(){
     }else{
         datos = {...datos, id_presupuesto: $("#id_presupuesto").val()};
         ejecutarAjax("controladores/presupuestos_compra.php","actualizar="+JSON.stringify(datos));
+
+        // Actualizar detalle
+        let detalle = {
+            id_detalle: $("#id_detalle").val(),
+            id_presupuesto: $("#id_presupuesto").val(),
+            id_producto: $("#id_producto_lst").val(),
+            cantidad: $("#cantidad_txt").val(),
+            precio_unitario: $("#precio_unitario_txt").val(),
+            subtotal: $("#subtotal_txt").val()
+        };
+        ejecutarAjax("controladores/detalle_presupuesto.php","actualizar="+JSON.stringify(detalle));
+
         alert("Actualizado correctamente");
     }
     mostrarListarPresupuestos();
@@ -110,6 +122,17 @@ $(document).on("click",".editar-presupuesto",function(){
     $("#id_proveedor_lst").val(json.id_proveedor);
     $("#fecha_txt").val(json.fecha);
     $("#total_txt").val(json.total_estimado);
+
+    // Cargar datos del detalle asociado
+    let det = ejecutarAjax("controladores/detalle_presupuesto.php","leer=1&id_presupuesto="+id);
+    if(det !== "0"){
+        let d = JSON.parse(det)[0];
+        $("#id_detalle").val(d.id_detalle);
+        $("#id_producto_lst").val(d.id_producto);
+        $("#cantidad_txt").val(d.cantidad);
+        $("#precio_unitario_txt").val(d.precio_unitario);
+        $("#subtotal_txt").val(d.subtotal);
+    }
 });
 
 $(document).on("click",".ver-detalle",function(){
@@ -192,6 +215,7 @@ function imprimirPresupuesto(id){
 
 function limpiarPresupuesto(){
     $("#id_presupuesto").val("0");
+    $("#id_detalle").val("0");
     $("#id_proveedor_lst").val("");
     $("#fecha_txt").val("");
     $("#total_txt").val("");


### PR DESCRIPTION
## Summary
- add hidden field for detail row id
- load detail data when editing a presupuesto
- update the detalle record when saving edits
- clear new hidden field on reset

## Testing
- `php -l paginas/referenciales/presupuestos_compra/agregar.php`

------
https://chatgpt.com/codex/tasks/task_e_688d00b3a7c08325bfd7135b8c6096a8