### PR TITLE
Add estado column to presupuestos and status actions

### DIFF
--- a/controladores/presupuestos_compra.php
+++ b/controladores/presupuestos_compra.php
@@ -7,7 +7,7 @@ if (isset($_POST['guardar'])) {
     $db = new DB();
     $cn = $db->conectar();
     $query = $cn->prepare(
-        "INSERT INTO presupuestos_compra (fecha, id_proveedor, total_estimado) VALUES (:fecha, :id_proveedor, :total_estimado)"
+        "INSERT INTO presupuestos_compra (fecha, id_proveedor, total_estimado, estado) VALUES (:fecha, :id_proveedor, :total_estimado, 'REALIZADO')"
     );
     $query->execute($datos);
     echo $cn->lastInsertId();
@@ -30,11 +30,25 @@ if (isset($_POST['eliminar'])) {
     $query->execute(["id" => $_POST['eliminar']]);
 }
 
+// APROBAR PRESUPUESTO
+if (isset($_POST['aprobar'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("UPDATE presupuestos_compra SET estado = 'APROBADO' WHERE id_presupuesto = :id");
+    $query->execute(['id' => $_POST['aprobar']]);
+}
+
+// ANULAR PRESUPUESTO
+if (isset($_POST['anular'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("UPDATE presupuestos_compra SET estado = 'ANULADO' WHERE id_presupuesto = :id");
+    $query->execute(['id' => $_POST['anular']]);
+}
+
 // LEER TODAS LOS PRESUPUESTOS
 if (isset($_POST['leer'])) {
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor ORDER BY p.id_presupuesto DESC"
+        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor ORDER BY p.id_presupuesto DESC"
     );
     $query->execute();
     if ($query->rowCount()) {
@@ -48,7 +62,7 @@ if (isset($_POST['leer'])) {
 if (isset($_POST['leer_id'])) {
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado " .
+        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado " .
         "FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor " .
         "WHERE p.id_presupuesto = :id"
     );
@@ -65,7 +79,7 @@ if (isset($_POST['leer_descripcion'])) {
     $f = '%' . $_POST['leer_descripcion'] . '%';
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE CONCAT(p.id_presupuesto, pr.razon_social) LIKE :filtro ORDER BY p.id_presupuesto DESC"
+        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE CONCAT(p.id_presupuesto, pr.razon_social) LIKE :filtro ORDER BY p.id_presupuesto DESC"
     );
     $query->execute(['filtro' => $f]);
     if ($query->rowCount()) {

--- a/paginas/referenciales/presupuestos_compra/listar.php
+++ b/paginas/referenciales/presupuestos_compra/listar.php
@@ -26,6 +26,7 @@
                             <th>Proveedor</th>
                             <th>Fecha</th>
                             <th>Total Estimado</th>
+                            <th>Estado</th>
                             <th>Operaciones</th>
                         </tr>
                     </thead>

--- a/utcdp1.sql
+++ b/utcdp1.sql
@@ -253,7 +253,8 @@ CREATE TABLE `presupuestos_compra` (
   `id_presupuesto` int(11) NOT NULL,
   `fecha` date NOT NULL,
   `id_proveedor` int(11) NOT NULL,
-  `total_estimado` decimal(10,2) NOT NULL
+  `total_estimado` decimal(10,2) NOT NULL,
+  `estado` varchar(20) NOT NULL DEFAULT 'REALIZADO'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -158,10 +158,12 @@ function cargarTablaPresupuesto(){
                     <td>${it.proveedor}</td>
                     <td>${it.fecha}</td>
                     <td>${it.total_estimado}</td>
+                    <td>${it.estado}</td>
                     <td>
                         <button class="btn btn-info ver-detalle">Imprimir</button>
+                        <button class="btn btn-success aprobar-presupuesto">Aprobar</button>
                         <button class="btn btn-warning editar-presupuesto">Editar</button>
-                        <button class="btn btn-danger eliminar-presupuesto">Eliminar</button>
+                        <button class="btn btn-danger anular-presupuesto">Anular</button>
                     </td>
                 </tr>`);
         });
@@ -191,10 +193,17 @@ $(document).on("click",".ver-detalle",function(){
     imprimirPresupuesto(id);
 });
 
-$(document).on("click",".eliminar-presupuesto",function(){
+$(document).on("click",".aprobar-presupuesto",function(){
     let id = $(this).closest("tr").find("td:eq(0)").text();
-    ejecutarAjax("controladores/presupuestos_compra.php","eliminar="+id);
-    alert("Eliminado");
+    ejecutarAjax("controladores/presupuestos_compra.php","aprobar="+id);
+    alert("Presupuesto aprobado");
+    cargarTablaPresupuesto();
+});
+
+$(document).on("click",".anular-presupuesto",function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    ejecutarAjax("controladores/presupuestos_compra.php","anular="+id);
+    alert("Presupuesto anulado");
     cargarTablaPresupuesto();
 });
 
@@ -222,10 +231,12 @@ function buscarPresupuesto(){
                     <td>${it.proveedor}</td>
                     <td>${it.fecha}</td>
                     <td>${it.total_estimado}</td>
+                    <td>${it.estado}</td>
                     <td>
                         <button class="btn btn-info ver-detalle">Detalles</button>
+                        <button class="btn btn-success aprobar-presupuesto">Aprobar</button>
                         <button class="btn btn-warning editar-presupuesto">Editar</button>
-                        <button class="btn btn-danger eliminar-presupuesto">Eliminar</button>
+                        <button class="btn btn-danger anular-presupuesto">Anular</button>
                     </td>
                 </tr>`);
         });


### PR DESCRIPTION
## Summary
- extend `presupuestos_compra` table with `estado`
- store status as `REALIZADO` when creating budgets
- allow approving and annulling budgets
- list the status in the budgets table with new approve/anular buttons

## Testing
- `php -l controladores/presupuestos_compra.php`
- `php -l paginas/referenciales/presupuestos_compra/listar.php`


------
https://chatgpt.com/codex/tasks/task_e_688d0d5526248325be7c69ad6e17f6c6