### PR TITLE
Add search filters in presupuesto form

### DIFF
--- a/paginas/referenciales/presupuestos_compra/agregar.php
+++ b/paginas/referenciales/presupuestos_compra/agregar.php
@@ -9,6 +9,7 @@
             <div class="row g-3">
                 <div class="col-md-6">
                     <label for="id_proveedor_lst" class="form-label">Proveedor</label>
+                    <input type="text" id="filtro_proveedor" class="form-control mb-2" placeholder="Buscar proveedor...">
                     <select id="id_proveedor_lst" class="form-select"></select>
                 </div>
                 <div class="col-md-6">
@@ -18,6 +19,7 @@
                
                 <div class="col-md-6">
                     <label for="id_producto_lst" class="form-label">Producto</label>
+                    <input type="text" id="filtro_producto" class="form-control mb-2" placeholder="Buscar producto...">
                     <select id="id_producto_lst" class="form-select"></select>
                 </div>
                  <div class="col-md-6">

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -1,4 +1,6 @@
 let detalles = [];
+let listaProveedores = [];
+let listaProductos = [];
 
 function mostrarListarPresupuestos(){
     let contenido = dameContenido("paginas/referenciales/presupuestos_compra/listar.php");
@@ -17,25 +19,47 @@ function mostrarAgregarPresupuesto(){
 function cargarListaProveedores(){
     let datos = ejecutarAjax("controladores/proveedor.php","leer=1");
     if(datos !== "0"){
-        let json = JSON.parse(datos);
-        let select = $("#id_proveedor_lst");
-        select.html('<option value="">-- Seleccione un proveedor --</option>');
-        json.map(function(p){
-            select.append(`<option value="${p.id_proveedor}">${p.razon_social}</option>`);
-        });
+        listaProveedores = JSON.parse(datos);
+        renderListaProveedores(listaProveedores);
     }
+}
+
+function renderListaProveedores(arr){
+    let select = $("#id_proveedor_lst");
+    select.html('<option value="">-- Seleccione un proveedor --</option>');
+    arr.forEach(function(p){
+        select.append(`<option value="${p.id_proveedor}">${p.razon_social}</option>`);
+    });
+}
+
+function filtrarProveedores(texto){
+    let filtrados = listaProveedores.filter(function(p){
+        return p.razon_social.toLowerCase().includes(texto.toLowerCase());
+    });
+    renderListaProveedores(filtrados);
 }
 
 function cargarListaProductos(){
     let datos = ejecutarAjax("controladores/productos.php", "leer=1");
     if(datos !== "0"){
-        let json = JSON.parse(datos);
-        let select = $("#id_producto_lst");
-        select.html('<option value="">-- Seleccione un producto --</option>');
-        json.map(function(p){
-            select.append(`<option value="${p.producto_id}">${p.nombre}</option>`);
-        });
+        listaProductos = JSON.parse(datos);
+        renderListaProductos(listaProductos);
     }
+}
+
+function renderListaProductos(arr){
+    let select = $("#id_producto_lst");
+    select.html('<option value="">-- Seleccione un producto --</option>');
+    arr.forEach(function(p){
+        select.append(`<option value="${p.producto_id}">${p.nombre}</option>`);
+    });
+}
+
+function filtrarProductos(texto){
+    let filtrados = listaProductos.filter(function(p){
+        return p.nombre.toLowerCase().includes(texto.toLowerCase());
+    });
+    renderListaProductos(filtrados);
 }
 
 function agregarDetalle(){
@@ -252,6 +276,14 @@ $(document).on("click",".quitar-detalle",function(){
     let idx = $(this).data("idx");
     detalles.splice(idx,1);
     renderDetalles();
+});
+
+$(document).on("keyup","#filtro_proveedor",function(){
+    filtrarProveedores($(this).val());
+});
+
+$(document).on("keyup","#filtro_producto",function(){
+    filtrarProductos($(this).val());
 });
 
 $(document).on("keyup","#b_presupuesto",function(){


### PR DESCRIPTION
## Summary
- add filter text inputs for providers and products when editing/adding presupuestos
- implement filtering logic in `presupuestos_compra.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d3435e03883259fe566ffaffe99d9