### PR TITLE
Filtrar proveedores inactivos en presupuestos

### DIFF
--- a/controladores/proveedor.php
+++ b/controladores/proveedor.php
@@ -39,6 +39,18 @@ if (isset($_POST['leer'])) {
     echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
 
+if (isset($_POST['leerActivo'])) {
+    $query = $db->prepare(
+        "SELECT p.id_proveedor, p.razon_social, p.ruc, p.direccion, p.telefono, p.estado, " .
+        "c.descripcion AS ciudad " .
+        "FROM proveedor p LEFT JOIN ciudad c ON p.id_ciudad = c.id_ciudad " .
+        "WHERE p.estado = 'ACTIVO' " .
+        "ORDER BY p.id_proveedor DESC"
+    );
+    $query->execute();
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
 if (isset($_POST['leer_descripcion'])) {
     $filtro = '%' . $_POST['leer_descripcion'] . '%';
     $query = $db->prepare(

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -17,7 +17,7 @@ function mostrarAgregarPresupuesto(){
 }
 
 function cargarListaProveedores(){
-    let datos = ejecutarAjax("controladores/proveedor.php","leer=1");
+    let datos = ejecutarAjax("controladores/proveedor.php","leerActivo=1");
     if(datos !== "0"){
         listaProveedores = JSON.parse(datos);
         renderListaProveedores(listaProveedores);


### PR DESCRIPTION
## Summary
- add `leerActivo` endpoint in `proveedor.php`
- use this endpoint from presupuesto JS so that only active providers appear

## Testing
- `php -l controladores/proveedor.php`


------
https://chatgpt.com/codex/tasks/task_e_688d3d7808e483259ed79d80e0ace08d