### PR TITLE
Hide inactive products in budgets

### DIFF
--- a/controladores/productos.php
+++ b/controladores/productos.php
@@ -37,6 +37,16 @@ if (isset($_POST['leer'])) {
     echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
 
+if (isset($_POST['leerActivo'])) {
+    $query = $db->prepare(
+        "SELECT producto_id, nombre, descripcion, precio, tipo, estado " .
+        "FROM productos WHERE estado = 'ACTIVO' " .
+        "ORDER BY producto_id DESC"
+    );
+    $query->execute();
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
 if (isset($_POST['leer_descripcion'])) {
     $filtro = '%' . $_POST['leer_descripcion'] . '%';
     $query = $db->prepare(

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -40,7 +40,7 @@ function filtrarProveedores(texto){
 }
 
 function cargarListaProductos(){
-    let datos = ejecutarAjax("controladores/productos.php", "leer=1");
+    let datos = ejecutarAjax("controladores/productos.php", "leerActivo=1");
     if(datos !== "0"){
         listaProductos = JSON.parse(datos);
         renderListaProductos(listaProductos);


### PR DESCRIPTION
## Summary
- show only active products in purchase budget dropdowns
- load active products in `presupuestos_compra.js`

## Testing
- `php -l controladores/productos.php`

------
https://chatgpt.com/codex/tasks/task_e_688d3f85a7988325af387754533eb9cf