### PR TITLE
Color code status states

### DIFF
--- a/paginas/referenciales/ciudad/print.php
+++ b/paginas/referenciales/ciudad/print.php
@@ -49,9 +49,18 @@ $ciudades = $query->fetchAll(PDO::FETCH_ASSOC);
                     <td><?= htmlspecialchars($ciudad['descripcion']) ?></td>
                     <td><?= htmlspecialchars($ciudad['departamentos']) ?></td>
                     <td>
-                        <span class="badge bg-<?= $ciudad['estado'] ? 'success' : 'secondary' ?>">
-                            <?= $ciudad['estado'] ? 'Activo' : 'Inactivo' ?>
-                        </span>
+                        <?php
+                            $est = strtoupper($ciudad['estado']);
+                            $class = 'secondary';
+                            if ($est === 'ACTIVO' || $est === 'APROBADO') {
+                                $class = 'success';
+                            } elseif ($est === 'PENDIENTE') {
+                                $class = 'warning text-dark';
+                            } elseif ($est === 'INACTIVO' || $est === 'ANULADO') {
+                                $class = 'danger';
+                            }
+                        ?>
+                        <span class="badge bg-<?= $class ?>"><?= htmlspecialchars($ciudad['estado']) ?></span>
                     </td>
                 </tr>
                 <?php endforeach; ?>

--- a/vistas/ciudad.js
+++ b/vistas/ciudad.js
@@ -151,7 +151,7 @@ function cargarTablaCiudad(){
                        <i>${item.departamentos}</i>
                    </div>
                    <div class="col-4">
-                       <i class="badge bg-secondary p-2">${item.estado}</i>
+                       ${badgeEstado(item.estado)}
                    </div>
                    <div class="col-12">
                        <hr>
@@ -256,7 +256,7 @@ $(document).on("keyup", "#b_ciudad", function (evt) {
                             <i>${item.departamento}</i>
                         </div>
                         <div class="col-4">
-                            <i class="badge bg-secondary p-2">${item.estado}</i>
+                            ${badgeEstado(item.estado)}
                         </div>
                         <div class="col-12">
                             <hr>

--- a/vistas/cliente.js
+++ b/vistas/cliente.js
@@ -87,7 +87,7 @@ function cargarTablaCliente(){
                     <td>${it.direccion}</td>
                     <td>${it.telefono}</td>
                     <td>${it.ciudad}</td>
-                    <td>${it.estado}</td>
+                    <td>${badgeEstado(it.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-cliente">Editar</button>
                         <button class="btn btn-danger eliminar-cliente">Eliminar</button>
@@ -161,7 +161,7 @@ function buscarCliente(){
                     <td>${it.direccion}</td>
                     <td>${it.telefono}</td>
                     <td>${it.ciudad}</td>
-                    <td>${it.estado}</td>
+                    <td>${badgeEstado(it.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-cliente">Editar</button>
                         <button class="btn btn-danger eliminar-cliente">Eliminar</button>

--- a/vistas/compras.js
+++ b/vistas/compras.js
@@ -98,7 +98,7 @@ function cargarTablaCompra(){
                     <td>${item.fecha}</td>
                     <td>${item.total}</td>
                     <td>${item.metodo_pago}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>${item.referencia || ""}</td>
                     <td>
                         <button class="btn btn-warning editar-compra">Editar</button>
@@ -172,7 +172,7 @@ $(document).on("keyup", "#b_compra", function (evt) {
                     <td>${item.fecha}</td>
                     <td>${item.total}</td>
                     <td>${item.metodo_pago}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>${item.referencia || ""}</td>
                     <td>
                         <button class="btn btn-warning editar-compra">Editar</button>

--- a/vistas/departamento.js
+++ b/vistas/departamento.js
@@ -73,7 +73,7 @@ function cargarTablaDepartamento(){
                 <tr>
                     <td>${item.id_departamento}</td>
                     <td>${item.descripcion}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-departamento">Editar</button>
                         <button class="btn btn-danger eliminar-departamento">Eliminar</button>
@@ -148,7 +148,7 @@ $(document).on("keyup", "#b_departamento", function (evt) {
                 <tr>
                     <td>${item.id_departamento}</td>
                     <td>${item.descripcion}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-departamento">Editar</button>
                         <button class="btn btn-danger eliminar-departamento">Eliminar</button>

--- a/vistas/persona.js
+++ b/vistas/persona.js
@@ -88,7 +88,7 @@ function cargarTablaProducto(){
                     <td>${item.ciudad}</td>
                     <td>${item.color}</td>
                     <td>${item.foto}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-persona">Editar</button>
                         <button class="btn btn-danger eliminar-persona">Eliminar</button>
@@ -180,7 +180,7 @@ $(document).on("keyup", "#busqueda_txt", function (evt) {
                     <td>${item.ciudad}</td>
                     <td>${item.color}</td>
                     <td>${item.foto}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-persona">Editar</button>
                         <button class="btn btn-danger eliminar-persona">Eliminar</button>

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -194,7 +194,7 @@ function cargarTablaPresupuesto(){
                     <td>${it.proveedor}</td>
                     <td>${it.fecha}</td>
                     <td>${formatearPY(it.total_estimado)}</td>
-                    <td>${it.estado}</td>
+                    <td>${badgeEstado(it.estado)}</td>
                     <td>
                         <button class="btn btn-info ver-detalle">Imprimir</button>
                         <button class="btn btn-success aprobar-presupuesto">Aprobar</button>
@@ -304,7 +304,7 @@ function buscarPresupuesto(){
                     <td>${it.proveedor}</td>
                     <td>${it.fecha}</td>
                     <td>${formatearPY(it.total_estimado)}</td>
-                    <td>${it.estado}</td>
+                    <td>${badgeEstado(it.estado)}</td>
                     <td>
                         <button class="btn btn-info ver-detalle">Detalles</button>
                         <button class="btn btn-success aprobar-presupuesto">Aprobar</button>

--- a/vistas/producto.js
+++ b/vistas/producto.js
@@ -93,7 +93,7 @@ function cargarTablaProducto(){
                     <td>${item.categoria}</td>
                     <td>${item.marca}</td>
                     <td>${item.codigodebarra}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-producto">Editar</button>
                         <button class="btn btn-danger eliminar-producto">Eliminar</button>
@@ -189,7 +189,7 @@ $(document).on("keyup", "#busqueda_txt", function (evt) {
                     <td>${item.marca}</td>
                     <td>${item.codigodebarra}</td>
                     <td>${item.fecha}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-producto">Editar</button>
                         <button class="btn btn-danger eliminar-producto">Eliminar</button>

--- a/vistas/productos.js
+++ b/vistas/productos.js
@@ -63,7 +63,7 @@ function cargarTablaProductos(){
                     <td>${it.descripcion}</td>
                     <td>${formatearPY(it.precio)}</td>
                     <td>${it.tipo}</td>
-                    <td>${it.estado}</td>
+                    <td>${badgeEstado(it.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-producto">Editar</button>
                         <button class="btn btn-danger eliminar-producto">Eliminar</button>
@@ -134,7 +134,7 @@ function buscarProducto(){
                     <td>${it.descripcion}</td>
                     <td>${formatearPY(it.precio)}</td>
                     <td>${it.tipo}</td>
-                    <td>${it.estado}</td>
+                    <td>${badgeEstado(it.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-producto">Editar</button>
                         <button class="btn btn-danger eliminar-producto">Eliminar</button>

--- a/vistas/proveedor.js
+++ b/vistas/proveedor.js
@@ -87,7 +87,7 @@ function cargarTablaProveedor(){
                     <td>${it.direccion}</td>
                     <td>${it.telefono}</td>
                     <td>${it.ciudad}</td>
-                    <td>${it.estado}</td>
+                    <td>${badgeEstado(it.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-proveedor">Editar</button>
                         <button class="btn btn-danger eliminar-proveedor">Eliminar</button>
@@ -162,7 +162,7 @@ function buscarProveedor(){
                     <td>${it.direccion}</td>
                     <td>${it.telefono}</td>
                     <td>${it.ciudad}</td>
-                    <td>${it.estado}</td>
+                    <td>${badgeEstado(it.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-proveedor">Editar</button>
                         <button class="btn btn-danger eliminar-proveedor">Eliminar</button>

--- a/vistas/usuarioss.js
+++ b/vistas/usuarioss.js
@@ -85,7 +85,7 @@ function cargarTablaUsuarioss() {
                     <td>${item.email}</td>
                     <td>${item.fecha_registro}</td>
                     <td>${item.tipo_usuario}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-usuarioss">Editar</button>
                         <button class="btn btn-danger eliminar-usuarioss">Eliminar</button>
@@ -145,7 +145,7 @@ $(document).on("keyup", "#b_usuarioss", function () {
                     <td>${item.email}</td>
                     <td>${item.fecha_registro}</td>
                     <td>${item.tipo_usuario}</td>
-                    <td>${item.estado}</td>
+                    <td>${badgeEstado(item.estado)}</td>
                     <td>
                         <button class="btn btn-warning editar-usuarioss">Editar</button>
                         <button class="btn btn-danger eliminar-usuarioss">Eliminar</button>

--- a/vistas/util.js
+++ b/vistas/util.js
@@ -132,6 +132,20 @@ function formatearPY(numero) {
     return new Intl.NumberFormat('es-PY').format(Math.round(numero));
 }
 
+// Devuelve un badge coloreado según el estado proporcionado
+function badgeEstado(estado) {
+    const est = (estado || '').toString().toUpperCase();
+    let clase = 'secondary';
+    if (est === 'ACTIVO' || est === 'APROBADO') {
+        clase = 'success';
+    } else if (est === 'PENDIENTE') {
+        clase = 'warning text-dark';
+    } else if (est === 'INACTIVO' || est === 'ANULADO') {
+        clase = 'danger';
+    }
+    return `<span class="badge bg-${clase}">${estado}</span>`;
+}
+
 
 
 function dameFechaActualFormateada() {


### PR DESCRIPTION
## Summary
- add `badgeEstado` utility for coloring statuses
- color-code status fields across JS modules
- adjust city print page to match new colors

## Testing
- `php -l paginas/referenciales/ciudad/print.php`


------
https://chatgpt.com/codex/tasks/task_e_688d41fd6534832585eacd3597297f0b