### PR TITLE
feat: add purchase order module

### DIFF
--- a/controladores/detalle_orden_compra.php
+++ b/controladores/detalle_orden_compra.php
@@ -1,0 +1,70 @@
+<?php
+require_once '../conexion/db.php';
+
+$db = new DB();
+$cn = $db->conectar();
+
+// GUARDAR DETALLE
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $query = $cn->prepare(
+        "INSERT INTO detalle_orden_compra (id_orden, id_producto, cantidad, precio_unitario, subtotal) VALUES (:id_orden, :id_producto, :cantidad, :precio_unitario, :subtotal)"
+    );
+    $query->execute($datos);
+}
+
+// ACTUALIZAR DETALLE
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $query = $cn->prepare(
+        "UPDATE detalle_orden_compra SET id_orden = :id_orden, id_producto = :id_producto, cantidad = :cantidad, precio_unitario = :precio_unitario, subtotal = :subtotal WHERE id_orden_detalle = :id_orden_detalle"
+    );
+    $query->execute($datos);
+}
+
+// ELIMINAR DETALLE
+if (isset($_POST['eliminar'])) {
+    $query = $cn->prepare("DELETE FROM detalle_orden_compra WHERE id_orden_detalle = :id");
+    $query->execute(['id' => $_POST['eliminar']]);
+}
+
+// LISTAR DETALLES
+if (isset($_POST['leer'])) {
+    $sql =
+        "SELECT d.id_orden_detalle, d.id_orden, d.id_producto, p.nombre AS producto, d.cantidad, d.precio_unitario, d.subtotal FROM detalle_orden_compra d LEFT JOIN productos p ON d.id_producto = p.producto_id";
+    $params = [];
+    if (!empty($_POST['id_orden'])) {
+        $sql .= " WHERE d.id_orden = :id_orden";
+        $params['id_orden'] = $_POST['id_orden'];
+    }
+    $sql .= " ORDER BY d.id_orden_detalle DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $query = $cn->prepare(
+        "SELECT id_orden_detalle, id_orden, id_producto, cantidad, precio_unitario, subtotal FROM detalle_orden_compra WHERE id_orden_detalle = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}
+
+// BUSCAR
+if (isset($_POST['leer_descripcion'])) {
+    $filtro = '%' . $_POST['leer_descripcion'] . '%';
+    $sql =
+        "SELECT d.id_orden_detalle, d.id_orden, d.id_producto, p.nombre AS producto, d.cantidad, d.precio_unitario, d.subtotal FROM detalle_orden_compra d LEFT JOIN productos p ON d.id_producto = p.producto_id WHERE CONCAT(d.id_orden_detalle, p.nombre, d.id_orden) LIKE :filtro";
+    $params = ['filtro' => $filtro];
+    if (!empty($_POST['id_orden'])) {
+        $sql .= " AND d.id_orden = :id_orden";
+        $params['id_orden'] = $_POST['id_orden'];
+    }
+    $sql .= " ORDER BY d.id_orden_detalle DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+?>

--- a/controladores/orden_compra.php
+++ b/controladores/orden_compra.php
@@ -1,0 +1,75 @@
+<?php
+require_once '../conexion/db.php';
+
+// GUARDAR ORDEN
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "INSERT INTO orden_compra (fecha_emision, estado, id_presupuesto, id_proveedor) VALUES (:fecha_emision, 'EMITIDO', :id_presupuesto, :id_proveedor)"
+    );
+    $query->execute($datos);
+    echo $cn->lastInsertId();
+}
+
+// ACTUALIZAR ORDEN
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "UPDATE orden_compra SET fecha_emision = :fecha_emision, id_presupuesto = :id_presupuesto, id_proveedor = :id_proveedor WHERE id_orden = :id_orden"
+    );
+    $query->execute($datos);
+}
+
+// ELIMINAR ORDEN
+if (isset($_POST['eliminar'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("DELETE FROM orden_compra WHERE id_orden = :id");
+    $query->execute(['id' => $_POST['eliminar']]);
+}
+
+// LEER TODAS LAS ORDENES
+if (isset($_POST['leer'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "SELECT o.id_orden, o.fecha_emision, o.id_presupuesto, o.id_proveedor, pr.razon_social AS proveedor, o.estado FROM orden_compra o LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor ORDER BY o.id_orden DESC"
+    );
+    $query->execute();
+    if ($query->rowCount()) {
+        echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "SELECT o.id_orden, o.fecha_emision, o.id_presupuesto, o.id_proveedor, pr.razon_social AS proveedor, o.estado FROM orden_compra o LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor WHERE o.id_orden = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    if ($query->rowCount()) {
+        echo json_encode($query->fetch(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+
+// LEER POR DESCRIPCION
+if (isset($_POST['leer_descripcion'])) {
+    $f = '%' . $_POST['leer_descripcion'] . '%';
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "SELECT o.id_orden, o.fecha_emision, o.id_presupuesto, o.id_proveedor, pr.razon_social AS proveedor, o.estado FROM orden_compra o LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor WHERE CONCAT(o.id_orden, pr.razon_social) LIKE :filtro ORDER BY o.id_orden DESC"
+    );
+    $query->execute(['filtro' => $f]);
+    if ($query->rowCount()) {
+        echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+?>

--- a/menu.php
+++ b/menu.php
@@ -391,6 +391,13 @@
   </a>
 </li>
 
+<li class="nav-item">
+  <a href="#" class="nav-link" onclick="mostrarListarOrdenes(); return false;">
+    <i class="nav-icon bi bi-file-earmark-text"></i>
+    <p>Órdenes de Compra</p>
+  </a>
+</li>
+
 
                   
                 </ul>
@@ -706,6 +713,7 @@
     <script src="vistas/ebooks.js"></script>
     <script src="vistas/compras.js"></script>
     <script src="vistas/presupuestos_compra.js"></script>
+    <script src="vistas/orden_compra.js"></script>
     <script src="vistas/categorias.js"></script>
     <script src="vistas/resenas.js"></script>
     <script src="vistas/proveedor.js"></script>

--- a/paginas/referenciales/orden_compra/agregar.php
+++ b/paginas/referenciales/orden_compra/agregar.php
@@ -1,0 +1,85 @@
+<div class="container mt-4">
+    <input type="hidden" id="id_orden" value="0">
+    <input type="hidden" id="id_detalle" value="0">
+    <input type="hidden" id="id_proveedor">
+    <div class="card shadow rounded-4">
+        <div class="card-header bg-success text-white rounded-top-4">
+            <h4 class="mb-0">Agregar / Editar Orden de Compra</h4>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="id_presupuesto_lst" class="form-label">Presupuesto</label>
+                    <select id="id_presupuesto_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-6">
+                    <label for="proveedor_txt" class="form-label">Proveedor</label>
+                    <input type="text" id="proveedor_txt" class="form-control" readonly>
+                </div>
+                <div class="col-md-6">
+                    <label for="fecha_txt" class="form-label">Fecha</label>
+                    <input type="date" id="fecha_txt" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="id_producto_lst" class="form-label">Producto</label>
+                    <input type="text" id="filtro_producto" class="form-control mb-2" placeholder="Buscar producto...">
+                    <select id="id_producto_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-3">
+                    <label for="cantidad_txt" class="form-label">Cantidad</label>
+                    <input type="number" id="cantidad_txt" class="form-control" min="0">
+                </div>
+                <div class="col-md-3">
+                    <label for="precio_unitario_txt" class="form-label">Costo Unitario</label>
+                    <input type="number" step="0.01" id="precio_unitario_txt" class="form-control">
+                </div>
+                <div class="col-md-3">
+                    <label for="subtotal_txt" class="form-label">Subtotal</label>
+                    <input type="number" step="0.01" id="subtotal_txt" class="form-control" readonly>
+                </div>
+                <div class="col-md-3 d-grid align-items-end">
+                    <button class="btn btn-primary" onclick="agregarDetalleOC(); return false;">
+                        <i class="bi bi-plus-lg"></i> Agregar Producto
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="card-footer text-end">
+            <button class="btn btn-success me-2" onclick="guardarOrden(); return false;">
+                <i class="bi bi-save"></i> Guardar
+            </button>
+            <button class="btn btn-danger" onclick="mostrarListarOrdenes(); return false;">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>
+<div class="container mt-4">
+    <div class="table-responsive">
+        <table class="table table-bordered text-center align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>Producto</th>
+                    <th>Cantidad</th>
+                    <th>Precio Unitario</th>
+                    <th>Subtotal</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody id="detalle_oc_tb">
+                <!-- filas detalle -->
+            </tbody>
+        </table>
+    </div>
+</div>
+<script>
+function formatearPY(numero) {
+    return new Intl.NumberFormat('es-PY').format(Math.round(numero));
+}
+$(document).on('input', '#cantidad_txt, #precio_unitario_txt', function () {
+    const cant = parseFloat($('#cantidad_txt').val()) || 0;
+    const precio = parseFloat($('#precio_unitario_txt').val()) || 0;
+    const subtotal = cant * precio;
+    $('#subtotal_txt').val(formatearPY(subtotal));
+});
+</script>

--- a/paginas/referenciales/orden_compra/listar.php
+++ b/paginas/referenciales/orden_compra/listar.php
@@ -1,0 +1,40 @@
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">Listado de Órdenes de Compra</h4>
+        <button class="btn btn-primary" onclick="mostrarAgregarOrden(); return false;">
+            <i class="bi bi-plus-circle"></i> Agregar
+        </button>
+    </div>
+    <div class="card shadow-sm rounded-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-8">
+                    <label for="b_orden" class="form-label">Buscador</label>
+                    <input type="text" id="b_orden" class="form-control" placeholder="Buscar por proveedor...">
+                </div>
+                <div class="col-md-4">
+                    <button class="btn btn-secondary w-100" onclick="buscarOrden(); return false;">
+                        <i class="bi bi-search"></i> Buscar
+                    </button>
+                </div>
+            </div>
+            <div class="table-responsive mt-4">
+                <table class="table table-bordered table-hover align-middle text-center">
+                    <thead class="table-light">
+                        <tr>
+                            <th>#</th>
+                            <th>Presupuesto</th>
+                            <th>Proveedor</th>
+                            <th>Fecha</th>
+                            <th>Estado</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="orden_datos_tb">
+                        <!-- Contenido dinámico -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/utcdp1.sql
+++ b/utcdp1.sql
@@ -271,6 +271,32 @@ CREATE TABLE `detalle_presupuesto` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `orden_compra`
+--
+CREATE TABLE `orden_compra` (
+  `id_orden` int(11) NOT NULL,
+  `fecha_emision` date NOT NULL,
+  `estado` varchar(20) NOT NULL DEFAULT 'EMITIDO',
+  `id_presupuesto` int(11) NOT NULL,
+  `id_proveedor` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `detalle_orden_compra`
+--
+CREATE TABLE `detalle_orden_compra` (
+  `id_orden_detalle` int(11) NOT NULL,
+  `id_orden` int(11) NOT NULL,
+  `id_producto` int(11) NOT NULL,
+  `cantidad` int(11) NOT NULL,
+  `precio_unitario` decimal(10,2) NOT NULL,
+  `subtotal` decimal(10,2) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+
 --
 -- Estructura de tabla para la tabla `resenas`
 --
@@ -402,6 +428,18 @@ ALTER TABLE `detalle_presupuesto`
   ADD PRIMARY KEY (`id_detalle`),
   ADD KEY `id_presupuesto` (`id_presupuesto`),
   ADD KEY `id_producto` (`id_producto`);
+
+-- Indices de la tabla `orden_compra`
+ALTER TABLE `orden_compra`
+  ADD PRIMARY KEY (`id_orden`),
+  ADD KEY `id_presupuesto` (`id_presupuesto`),
+  ADD KEY `id_proveedor` (`id_proveedor`);
+
+-- Indices de la tabla `detalle_orden_compra`
+ALTER TABLE `detalle_orden_compra`
+  ADD PRIMARY KEY (`id_orden_detalle`),
+  ADD KEY `id_orden` (`id_orden`),
+  ADD KEY `id_producto` (`id_producto`);
 --
 -- Indices de la tabla `proveedor`
 --
@@ -506,6 +544,12 @@ ALTER TABLE `presupuestos_compra`
 -- AUTO_INCREMENT de la tabla `detalle_presupuesto`
 ALTER TABLE `detalle_presupuesto`
   MODIFY `id_detalle` int(11) NOT NULL AUTO_INCREMENT;
+-- AUTO_INCREMENT de la tabla `orden_compra`
+ALTER TABLE `orden_compra`
+  MODIFY `id_orden` int(11) NOT NULL AUTO_INCREMENT;
+-- AUTO_INCREMENT de la tabla `detalle_orden_compra`
+ALTER TABLE `detalle_orden_compra`
+  MODIFY `id_orden_detalle` int(11) NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT de la tabla `resenas`
 --
@@ -548,6 +592,16 @@ ALTER TABLE `presupuestos_compra`
 ALTER TABLE `detalle_presupuesto`
   ADD CONSTRAINT `detalle_presupuesto_ibfk_1` FOREIGN KEY (`id_presupuesto`) REFERENCES `presupuestos_compra` (`id_presupuesto`),
   ADD CONSTRAINT `detalle_presupuesto_ibfk_2` FOREIGN KEY (`id_producto`) REFERENCES `productos` (`producto_id`);
+
+-- Filtros para la tabla `orden_compra`
+ALTER TABLE `orden_compra`
+  ADD CONSTRAINT `orden_compra_ibfk_1` FOREIGN KEY (`id_presupuesto`) REFERENCES `presupuestos_compra` (`id_presupuesto`),
+  ADD CONSTRAINT `orden_compra_ibfk_2` FOREIGN KEY (`id_proveedor`) REFERENCES `proveedor` (`id_proveedor`);
+
+-- Filtros para la tabla `detalle_orden_compra`
+ALTER TABLE `detalle_orden_compra`
+  ADD CONSTRAINT `detalle_orden_compra_ibfk_1` FOREIGN KEY (`id_orden`) REFERENCES `orden_compra` (`id_orden`),
+  ADD CONSTRAINT `detalle_orden_compra_ibfk_2` FOREIGN KEY (`id_producto`) REFERENCES `productos` (`producto_id`);
 --
 -- Filtros para la tabla `resenas`
 --

--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -1,0 +1,258 @@
+let detallesOC = [];
+let listaPresupuestos = [];
+let listaProductos = [];
+
+function mostrarListarOrdenes(){
+    let contenido = dameContenido("paginas/referenciales/orden_compra/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaOrden();
+}
+
+function mostrarAgregarOrden(){
+    let contenido = dameContenido("paginas/referenciales/orden_compra/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaPresupuestos();
+    cargarListaProductos();
+    limpiarOrden();
+}
+
+function cargarListaPresupuestos(){
+    let datos = ejecutarAjax("controladores/presupuestos_compra.php","leer=1");
+    if(datos !== "0"){
+        listaPresupuestos = JSON.parse(datos);
+        renderListaPresupuestos(listaPresupuestos);
+    }
+}
+
+function renderListaPresupuestos(arr){
+    let select = $("#id_presupuesto_lst");
+    select.html('<option value="">-- Seleccione un presupuesto --</option>');
+    arr.forEach(function(p){
+        select.append(`<option value="${p.id_presupuesto}" data-prov="${p.id_proveedor}" data-prov-nombre="${p.proveedor}">Presupuesto #${p.id_presupuesto}</option>`);
+    });
+}
+
+$(document).on('change','#id_presupuesto_lst',function(){
+   let id = $(this).val();
+   if(id === ""){
+       $("#proveedor_txt").val('');
+       $("#id_proveedor").val('');
+       detallesOC = [];
+       renderDetallesOC();
+       return;
+   }
+   let datos = ejecutarAjax("controladores/presupuestos_compra.php","leer_id="+id);
+   if(datos !== "0"){
+       let p = JSON.parse(datos);
+       $("#proveedor_txt").val(p.proveedor || p.id_proveedor);
+       $("#id_proveedor").val(p.id_proveedor);
+       let det = ejecutarAjax("controladores/detalle_presupuesto.php","leer=1&id_presupuesto="+id);
+       if(det !== "0"){
+           detallesOC = JSON.parse(det).map(d => ({id_orden_detalle:0,id_producto:d.id_producto,producto:d.producto,cantidad:d.cantidad,precio_unitario:d.precio_unitario,subtotal:d.subtotal}));
+       }else{
+           detallesOC = [];
+       }
+       renderDetallesOC();
+   }
+});
+
+function cargarListaProductos(){
+    let datos = ejecutarAjax("controladores/productos.php","leerActivo=1");
+    if(datos !== "0"){
+        listaProductos = JSON.parse(datos);
+        renderListaProductos(listaProductos);
+    }
+}
+
+function renderListaProductos(arr){
+    let select = $("#id_producto_lst");
+    select.html('<option value="">-- Seleccione un producto --</option>');
+    arr.forEach(function(p){
+        select.append(`<option value="${p.producto_id}">${p.nombre}</option>`);
+    });
+}
+
+function filtrarProductos(texto){
+    let filtrados = listaProductos.filter(function(p){
+        return p.nombre.toLowerCase().includes(texto.toLowerCase());
+    });
+    renderListaProductos(filtrados);
+}
+
+$(document).on('keyup','#filtro_producto',function(){
+    filtrarProductos($(this).val());
+});
+
+function agregarDetalleOC(){
+    if($("#id_producto_lst").val() === ""){
+        mensaje_dialogo_info_ERROR("Debe seleccionar un producto","ERROR");
+        return;
+    }
+    if($("#cantidad_txt").val().trim().length === 0){
+        mensaje_dialogo_info_ERROR("Debe ingresar la cantidad","ERROR");
+        return;
+    }
+    if($("#precio_unitario_txt").val().trim().length === 0){
+        mensaje_dialogo_info_ERROR("Debe ingresar el costo","ERROR");
+        return;
+    }
+    let detalle = {
+        id_orden_detalle:0,
+        id_producto:$("#id_producto_lst").val(),
+        producto:$("#id_producto_lst option:selected").text(),
+        cantidad:$("#cantidad_txt").val(),
+        precio_unitario:$("#precio_unitario_txt").val(),
+        subtotal:(parseFloat($("#cantidad_txt").val())||0)*(parseFloat($("#precio_unitario_txt").val())||0)
+    };
+    detallesOC.push(detalle);
+    renderDetallesOC();
+    limpiarDetalleOCForm();
+}
+
+function renderDetallesOC(){
+    let tbody = $("#detalle_oc_tb");
+    tbody.html("");
+    detallesOC.forEach(function(d,idx){
+        tbody.append(`<tr>
+            <td>${d.producto}</td>
+            <td>${d.cantidad}</td>
+            <td>${d.precio_unitario}</td>
+            <td>${d.subtotal}</td>
+            <td><button class="btn btn-danger btn-sm quitar-detalle-oc" data-idx="${idx}" title="Eliminar"><i class="bi bi-trash"></i></button></td>
+        </tr>`);
+    });
+}
+
+$(document).on('click','.quitar-detalle-oc',function(){
+    let idx = $(this).data('idx');
+    detallesOC.splice(idx,1);
+    renderDetallesOC();
+});
+
+function limpiarDetalleOCForm(){
+    $("#id_producto_lst").val("");
+    $("#cantidad_txt").val("");
+    $("#precio_unitario_txt").val("");
+    $("#subtotal_txt").val("");
+}
+
+function guardarOrden(){
+    if($("#id_presupuesto_lst").val() === ""){mensaje_dialogo_info_ERROR("Debe seleccionar un presupuesto","ERROR");return;}
+    if($("#fecha_txt").val().trim().length===0){mensaje_dialogo_info_ERROR("Debe ingresar la fecha","ERROR");return;}
+    if(detallesOC.length === 0){mensaje_dialogo_info_ERROR("Debe agregar al menos un producto","ERROR");return;}
+    let datos = {
+        id_presupuesto: $("#id_presupuesto_lst").val(),
+        id_proveedor: $("#id_proveedor").val(),
+        fecha_emision: $("#fecha_txt").val()
+    };
+    if($("#id_orden").val() === "0"){
+        let id = ejecutarAjax("controladores/orden_compra.php","guardar="+JSON.stringify(datos));
+        detallesOC.forEach(function(d){
+            let det = {
+                id_orden: id,
+                id_producto: d.id_producto,
+                cantidad: d.cantidad,
+                precio_unitario: d.precio_unitario,
+                subtotal: d.subtotal
+            };
+            ejecutarAjax("controladores/detalle_orden_compra.php","guardar="+JSON.stringify(det));
+        });
+        mensaje_confirmacion("REALIZADO","Guardado correctamente");
+    }else{
+        datos = {...datos, id_orden: $("#id_orden").val()};
+        ejecutarAjax("controladores/orden_compra.php","actualizar="+JSON.stringify(datos));
+        detallesOC.forEach(function(d){
+            if(d.id_orden_detalle && d.id_orden_detalle != 0){
+                let det = {
+                    id_orden_detalle: d.id_orden_detalle,
+                    id_orden: $("#id_orden").val(),
+                    id_producto: d.id_producto,
+                    cantidad: d.cantidad,
+                    precio_unitario: d.precio_unitario,
+                    subtotal: d.subtotal
+                };
+                ejecutarAjax("controladores/detalle_orden_compra.php","actualizar="+JSON.stringify(det));
+            }else{
+                let det = {
+                    id_orden: $("#id_orden").val(),
+                    id_producto: d.id_producto,
+                    cantidad: d.cantidad,
+                    precio_unitario: d.precio_unitario,
+                    subtotal: d.subtotal
+                };
+                ejecutarAjax("controladores/detalle_orden_compra.php","guardar="+JSON.stringify(det));
+            }
+        });
+        mensaje_confirmacion("REALIZADO","Actualizado correctamente");
+    }
+    mostrarListarOrdenes();
+}
+
+function limpiarOrden(){
+    $("#id_orden").val("0");
+    $("#id_presupuesto_lst").val("");
+    $("#proveedor_txt").val("");
+    $("#id_proveedor").val("");
+    $("#fecha_txt").val("");
+    detallesOC = [];
+    renderDetallesOC();
+}
+
+function cargarTablaOrden(){
+    let datos = ejecutarAjax("controladores/orden_compra.php","leer=1");
+    if(datos !== "0"){
+        renderTablaOrden(JSON.parse(datos));
+    }else{
+        $("#orden_datos_tb").html("");
+    }
+}
+
+function renderTablaOrden(arr){
+    let tbody = $("#orden_datos_tb");
+    tbody.html("");
+    arr.forEach(function(o){
+        tbody.append(`<tr>
+            <td>${o.id_orden}</td>
+            <td>${o.id_presupuesto}</td>
+            <td>${o.proveedor || o.id_proveedor}</td>
+            <td>${formatearFechaDMA(o.fecha_emision)}</td>
+            <td>${o.estado}</td>
+            <td>
+                <button class="btn btn-warning btn-sm editar-orden" data-id="${o.id_orden}" title="Editar"><i class="bi bi-pencil"></i></button>
+                <button class="btn btn-danger btn-sm eliminar-orden" data-id="${o.id_orden}" title="Eliminar"><i class="bi bi-trash"></i></button>
+            </td>
+        </tr>`);
+    });
+}
+
+$(document).on('click','.editar-orden',function(){
+    let id = $(this).data('id');
+    let datos = ejecutarAjax("controladores/orden_compra.php","leer_id="+id);
+    if(datos === "0"){ alert("No se encontró la orden"); return; }
+    let json = JSON.parse(datos);
+    mostrarAgregarOrden();
+    $("#id_orden").val(json.id_orden);
+    $("#id_presupuesto_lst").val(json.id_presupuesto).trigger('change');
+    $("#fecha_txt").val(json.fecha_emision);
+});
+
+$(document).on('click','.eliminar-orden',function(){
+    if(confirm('¿Desea eliminar?')){
+        let id = $(this).data('id');
+        ejecutarAjax("controladores/orden_compra.php","eliminar="+id);
+        cargarTablaOrden();
+    }
+});
+
+function buscarOrden(){
+    let datos = ejecutarAjax("controladores/orden_compra.php","leer_descripcion="+$("#b_orden").val());
+    if(datos !== "0"){
+        renderTablaOrden(JSON.parse(datos));
+    }else{
+        $("#orden_datos_tb").html("");
+    }
+}
+
+$(document).on('keyup','#b_orden',function(){
+    buscarOrden();
+});


### PR DESCRIPTION
## Summary
- add `orden_compra` and `detalle_orden_compra` tables
- implement controllers, pages and JS for purchase orders with provider auto-select from budget
- link purchase order module in menu

## Testing
- `php -l controladores/orden_compra.php`
- `php -l controladores/detalle_orden_compra.php`
- `php -l paginas/referenciales/orden_compra/listar.php`
- `php -l paginas/referenciales/orden_compra/agregar.php`


------
https://chatgpt.com/codex/tasks/task_e_688e1c6368c48325a28ebada0e174184