### PR TITLE
Fix purchase order module click handling

### DIFF
--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -256,3 +256,12 @@ function buscarOrden(){
 $(document).on('keyup','#b_orden',function(){
     buscarOrden();
 });
+
+// Expose functions to the global scope so they can be used
+// from inline HTML event handlers.
+window.mostrarListarOrdenes = mostrarListarOrdenes;
+window.mostrarAgregarOrden = mostrarAgregarOrden;
+window.agregarDetalleOC = agregarDetalleOC;
+window.guardarOrden = guardarOrden;
+window.buscarOrden = buscarOrden;
+


### PR DESCRIPTION
## Summary
- Expose purchase order JS functions on `window` so menu links can invoke them

## Testing
- `node --check vistas/orden_compra.js`
- `php -l controladores/orden_compra.php`


------
https://chatgpt.com/codex/tasks/task_e_688e2129067883259a73eae50dceb286