### PR TITLE
Add purchase order listing and budget-based form

### DIFF
--- a/controladores/detalle_orden_compra.php
+++ b/controladores/detalle_orden_compra.php
@@ -28,6 +28,12 @@ if (isset($_POST['eliminar'])) {
     $query->execute(['id' => $_POST['eliminar']]);
 }
 
+// ELIMINAR DETALLES POR ORDEN
+if (isset($_POST['eliminar_por_orden'])) {
+    $query = $cn->prepare("DELETE FROM detalle_orden_compra WHERE id_orden = :id");
+    $query->execute(['id' => $_POST['eliminar_por_orden']]);
+}
+
 // LISTAR DETALLES
 if (isset($_POST['leer'])) {
     $sql =

--- a/controladores/orden_compra.php
+++ b/controladores/orden_compra.php
@@ -34,7 +34,11 @@ if (isset($_POST['eliminar'])) {
 if (isset($_POST['leer'])) {
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT o.id_orden, o.fecha_emision, o.id_presupuesto, o.id_proveedor, pr.razon_social AS proveedor, o.estado FROM orden_compra o LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor ORDER BY o.id_orden DESC"
+        "SELECT o.id_orden, o.fecha_emision, o.id_presupuesto, o.id_proveedor, pr.razon_social AS proveedor, o.estado, IFNULL(SUM(d.subtotal),0) AS total " .
+        "FROM orden_compra o " .
+        "LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor " .
+        "LEFT JOIN detalle_orden_compra d ON o.id_orden = d.id_orden " .
+        "GROUP BY o.id_orden ORDER BY o.id_orden DESC"
     );
     $query->execute();
     if ($query->rowCount()) {
@@ -48,7 +52,11 @@ if (isset($_POST['leer'])) {
 if (isset($_POST['leer_id'])) {
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT o.id_orden, o.fecha_emision, o.id_presupuesto, o.id_proveedor, pr.razon_social AS proveedor, o.estado FROM orden_compra o LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor WHERE o.id_orden = :id"
+        "SELECT o.id_orden, o.fecha_emision, o.id_presupuesto, o.id_proveedor, pr.razon_social AS proveedor, o.estado, IFNULL(SUM(d.subtotal),0) AS total " .
+        "FROM orden_compra o " .
+        "LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor " .
+        "LEFT JOIN detalle_orden_compra d ON o.id_orden = d.id_orden " .
+        "WHERE o.id_orden = :id GROUP BY o.id_orden"
     );
     $query->execute(['id' => $_POST['leer_id']]);
     if ($query->rowCount()) {
@@ -63,7 +71,11 @@ if (isset($_POST['leer_descripcion'])) {
     $f = '%' . $_POST['leer_descripcion'] . '%';
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT o.id_orden, o.fecha_emision, o.id_presupuesto, o.id_proveedor, pr.razon_social AS proveedor, o.estado FROM orden_compra o LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor WHERE CONCAT(o.id_orden, pr.razon_social) LIKE :filtro ORDER BY o.id_orden DESC"
+        "SELECT o.id_orden, o.fecha_emision, o.id_presupuesto, o.id_proveedor, pr.razon_social AS proveedor, o.estado, IFNULL(SUM(d.subtotal),0) AS total " .
+        "FROM orden_compra o " .
+        "LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor " .
+        "LEFT JOIN detalle_orden_compra d ON o.id_orden = d.id_orden " .
+        "WHERE CONCAT(o.id_orden, pr.razon_social) LIKE :filtro GROUP BY o.id_orden ORDER BY o.id_orden DESC"
     );
     $query->execute(['filtro' => $f]);
     if ($query->rowCount()) {

--- a/paginas/referenciales/orden_compra/agregar.php
+++ b/paginas/referenciales/orden_compra/agregar.php
@@ -1,6 +1,5 @@
 <div class="container mt-4">
     <input type="hidden" id="id_orden" value="0">
-    <input type="hidden" id="id_detalle" value="0">
     <input type="hidden" id="id_proveedor">
     <div class="card shadow rounded-4">
         <div class="card-header bg-success text-white rounded-top-4">
@@ -19,28 +18,6 @@
                 <div class="col-md-6">
                     <label for="fecha_txt" class="form-label">Fecha</label>
                     <input type="date" id="fecha_txt" class="form-control">
-                </div>
-                <div class="col-md-6">
-                    <label for="id_producto_lst" class="form-label">Producto</label>
-                    <input type="text" id="filtro_producto" class="form-control mb-2" placeholder="Buscar producto...">
-                    <select id="id_producto_lst" class="form-select"></select>
-                </div>
-                <div class="col-md-3">
-                    <label for="cantidad_txt" class="form-label">Cantidad</label>
-                    <input type="number" id="cantidad_txt" class="form-control" min="0">
-                </div>
-                <div class="col-md-3">
-                    <label for="precio_unitario_txt" class="form-label">Costo Unitario</label>
-                    <input type="number" step="0.01" id="precio_unitario_txt" class="form-control">
-                </div>
-                <div class="col-md-3">
-                    <label for="subtotal_txt" class="form-label">Subtotal</label>
-                    <input type="number" step="0.01" id="subtotal_txt" class="form-control" readonly>
-                </div>
-                <div class="col-md-3 d-grid align-items-end">
-                    <button class="btn btn-primary" onclick="agregarDetalleOC(); return false;">
-                        <i class="bi bi-plus-lg"></i> Agregar Producto
-                    </button>
                 </div>
             </div>
         </div>
@@ -63,7 +40,6 @@
                     <th>Cantidad</th>
                     <th>Precio Unitario</th>
                     <th>Subtotal</th>
-                    <th>Acciones</th>
                 </tr>
             </thead>
             <tbody id="detalle_oc_tb">
@@ -72,14 +48,3 @@
         </table>
     </div>
 </div>
-<script>
-function formatearPY(numero) {
-    return new Intl.NumberFormat('es-PY').format(Math.round(numero));
-}
-$(document).on('input', '#cantidad_txt, #precio_unitario_txt', function () {
-    const cant = parseFloat($('#cantidad_txt').val()) || 0;
-    const precio = parseFloat($('#precio_unitario_txt').val()) || 0;
-    const subtotal = cant * precio;
-    $('#subtotal_txt').val(formatearPY(subtotal));
-});
-</script>

--- a/paginas/referenciales/orden_compra/listar.php
+++ b/paginas/referenciales/orden_compra/listar.php
@@ -23,9 +23,9 @@
                     <thead class="table-light">
                         <tr>
                             <th>#</th>
-                            <th>Presupuesto</th>
-                            <th>Proveedor</th>
                             <th>Fecha</th>
+                            <th>Proveedor</th>
+                            <th>Total</th>
                             <th>Estado</th>
                             <th>Operaciones</th>
                         </tr>


### PR DESCRIPTION
## Summary
- List purchase orders with date, provider, total and status
- Create purchase orders from approved budgets with prefilled provider and product details
- Compute order totals and allow resetting detail rows on update

## Testing
- `php -l controladores/orden_compra.php`
- `php -l controladores/detalle_orden_compra.php`
- `php -l paginas/referenciales/orden_compra/agregar.php`
- `php -l paginas/referenciales/orden_compra/listar.php`
- `node -c vistas/orden_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_688e284417a48325acbf98cc6c9340d5