### PR TITLE
feat: add extra product field in purchase order form

### DIFF
--- a/paginas/referenciales/orden_compra/agregar.php
+++ b/paginas/referenciales/orden_compra/agregar.php
@@ -20,6 +20,29 @@
                     <input type="date" id="fecha_txt" class="form-control">
                 </div>
             </div>
+            <div class="row g-3 mt-3">
+                <div class="col-md-4">
+                    <label for="id_producto_lst" class="form-label">Producto</label>
+                    <select id="id_producto_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-2">
+                    <label for="cantidad_txt" class="form-label">Cantidad</label>
+                    <input type="number" id="cantidad_txt" class="form-control" min="0">
+                </div>
+                <div class="col-md-2">
+                    <label for="precio_unitario_txt" class="form-label">Precio Unitario</label>
+                    <input type="number" step="0.01" id="precio_unitario_txt" class="form-control">
+                </div>
+                <div class="col-md-2">
+                    <label for="subtotal_txt" class="form-label">Subtotal</label>
+                    <input type="number" step="0.01" id="subtotal_txt" class="form-control" readonly>
+                </div>
+                <div class="col-md-2 d-grid align-items-end">
+                    <button class="btn btn-primary" onclick="agregarProductoExtra(); return false;">
+                        <i class="bi bi-plus-lg"></i> Agregar Producto
+                    </button>
+                </div>
+            </div>
         </div>
         <div class="card-footer text-end">
             <button class="btn btn-success me-2" onclick="guardarOrden(); return false;">


### PR DESCRIPTION
## Summary
- allow adding extra product when creating a purchase order
- auto-save new product into linked budget and update its total

## Testing
- `php -l paginas/referenciales/orden_compra/agregar.php`
- `node --check vistas/orden_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_688e2a8808d48325b58f9ff638e35bcd