### PR TITLE
Aprobar presupuesto al guardar orden de compra

### DIFF
--- a/controladores/orden_compra.php
+++ b/controladores/orden_compra.php
@@ -10,7 +10,13 @@ if (isset($_POST['guardar'])) {
         "INSERT INTO orden_compra (fecha_emision, estado, id_presupuesto, id_proveedor) VALUES (:fecha_emision, 'EMITIDO', :id_presupuesto, :id_proveedor)"
     );
     $query->execute($datos);
-    echo $cn->lastInsertId();
+    $idOrden = $cn->lastInsertId();
+
+    // Cambiar estado del presupuesto asociado a APROBADO
+    $update = $cn->prepare("UPDATE presupuestos_compra SET estado = 'APROBADO' WHERE id_presupuesto = :id_presupuesto");
+    $update->execute(['id_presupuesto' => $datos['id_presupuesto']]);
+
+    echo $idOrden;
 }
 
 // ACTUALIZAR ORDEN
@@ -21,6 +27,10 @@ if (isset($_POST['actualizar'])) {
         "UPDATE orden_compra SET fecha_emision = :fecha_emision, id_presupuesto = :id_presupuesto, id_proveedor = :id_proveedor WHERE id_orden = :id_orden"
     );
     $query->execute($datos);
+
+    // Asegurar que el presupuesto quede aprobado
+    $up = $db->conectar()->prepare("UPDATE presupuestos_compra SET estado = 'APROBADO' WHERE id_presupuesto = :id_presupuesto");
+    $up->execute(['id_presupuesto' => $datos['id_presupuesto']]);
 }
 
 // ELIMINAR ORDEN

--- a/controladores/presupuestos_compra.php
+++ b/controladores/presupuestos_compra.php
@@ -30,13 +30,6 @@ if (isset($_POST['eliminar'])) {
     $query->execute(["id" => $_POST['eliminar']]);
 }
 
-// APROBAR PRESUPUESTO
-if (isset($_POST['aprobar'])) {
-    $db = new DB();
-    $query = $db->conectar()->prepare("UPDATE presupuestos_compra SET estado = 'APROBADO' WHERE id_presupuesto = :id");
-    $query->execute(['id' => $_POST['aprobar']]);
-}
-
 // ANULAR PRESUPUESTO
 if (isset($_POST['anular'])) {
     $db = new DB();

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -202,9 +202,6 @@ function cargarTablaPresupuesto(){
                         <button class="btn btn-info ver-detalle" ${disabled} title="Imprimir">
                             <i class="bi bi-printer"></i>
                         </button>
-                        <button class="btn btn-success aprobar-presupuesto" ${disabled} title="Aprobar">
-                            <i class="bi bi-check-circle"></i>
-                        </button>
                         <button class="btn btn-warning editar-presupuesto" ${disabled} title="Editar">
                             <i class="bi bi-pencil-square"></i>
                         </button>
@@ -241,43 +238,6 @@ $(document).on("click",".ver-detalle",function(){
     let id = $(this).closest("tr").find("td:eq(0)").text();
     imprimirPresupuesto(id);
 });
-
-$(document).on("click", ".aprobar-presupuesto", function () {
-    if($(this).prop('disabled')) return;
-    let id = $(this).closest("tr").find("td:eq(0)").text();
-
-    // Aprobar en backend
-    ejecutarAjax("controladores/presupuestos_compra.php", "aprobar=" + id);
-
- 
-    Swal.fire({
-        icon: "success",
-        title: "REALIZADO",
-        text: "Presupuesto Aprobado",
-        confirmButtonText: "Aceptar",
-        confirmButtonColor: "#28a745"
-    }).then(() => {
-  
-        Swal.fire({
-            title: "¿Desea imprimir el presupuesto?",
-            icon: "question",
-            showCancelButton: true,
-            confirmButtonText: "Sí",
-            cancelButtonText: "No",
-            confirmButtonColor: "#28a745",
-            cancelButtonColor: "#dc3545",
-            reverseButtons: true
-        }).then((result) => {
-            if (result.isConfirmed) {
-                imprimirPresupuesto(id);
-            }
-        });
-
-        // Actualiza tabla después de ambos Swal
-        cargarTablaPresupuesto();
-    });
-});
-
 
 $(document).on("click",".anular-presupuesto",function(){
     if($(this).prop('disabled')) return;
@@ -324,9 +284,6 @@ function buscarPresupuesto(){
                     <td>
                         <button class="btn btn-info ver-detalle" ${disabled} title="Imprimir">
                             <i class="bi bi-printer"></i>
-                        </button>
-                        <button class="btn btn-success aprobar-presupuesto" ${disabled} title="Aprobar">
-                            <i class="bi bi-check-circle"></i>
                         </button>
                         <button class="btn btn-warning editar-presupuesto" ${disabled} title="Editar">
                             <i class="bi bi-pencil-square"></i>


### PR DESCRIPTION
## Summary
- Eliminar el botón de aprobación manual en la vista de presupuestos y su manejador de eventos.
- Aprobar automáticamente el presupuesto vinculado al guardar o actualizar una orden de compra.
- Retirar el endpoint de aprobación manual en el controlador de presupuestos.

## Testing
- `php -l controladores/presupuestos_compra.php`
- `php -l controladores/orden_compra.php`


------
https://chatgpt.com/codex/tasks/task_e_688e537055b08325b501d566f28e2efa