### PR TITLE
Filtrar presupuestos pendientes en orden de compra

### DIFF
--- a/controladores/presupuestos_compra.php
+++ b/controladores/presupuestos_compra.php
@@ -51,6 +51,20 @@ if (isset($_POST['leer'])) {
     }
 }
 
+// LEER PRESUPUESTOS PENDIENTES
+if (isset($_POST['leerPendiente'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare(
+        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE p.estado = 'PENDIENTE' ORDER BY p.id_presupuesto DESC"
+    );
+    $query->execute();
+    if ($query->rowCount()) {
+        echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+
 // LEER POR ID
 if (isset($_POST['leer_id'])) {
     $db = new DB();

--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -23,7 +23,7 @@ function mostrarAgregarOrden(){
 window.mostrarAgregarOrden = mostrarAgregarOrden;
 
 function cargarListaPresupuestos(){
-    let datos = ejecutarAjax("controladores/presupuestos_compra.php","leer=1");
+    let datos = ejecutarAjax("controladores/presupuestos_compra.php","leerPendiente=1");
     if(datos !== "0"){
         listaPresupuestos = JSON.parse(datos);
         renderListaPresupuestos(listaPresupuestos);


### PR DESCRIPTION
## Summary
- Mostrar solo presupuestos con estado PENDIENTE al agregar orden de compra
- Añadir endpoint para listar presupuestos en estado pendiente

## Testing
- `php -l controladores/presupuestos_compra.php`
- `node -c vistas/orden_compra.js`
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e9708ef308325913e8437ec776878