### PR TITLE
Add remision module with dynamic product form

### DIFF
--- a/controladores/detalle_remision.php
+++ b/controladores/detalle_remision.php
@@ -1,0 +1,76 @@
+<?php
+require_once '../conexion/db.php';
+
+$db = new DB();
+$cn = $db->conectar();
+
+// GUARDAR DETALLE
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $query = $cn->prepare(
+        "INSERT INTO detalle_remision (id_remision, id_producto, cantidad, precio_unitario, subtotal) VALUES (:id_remision, :id_producto, :cantidad, :precio_unitario, :subtotal)"
+    );
+    $query->execute($datos);
+}
+
+// ACTUALIZAR DETALLE
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $query = $cn->prepare(
+        "UPDATE detalle_remision SET id_remision = :id_remision, id_producto = :id_producto, cantidad = :cantidad, precio_unitario = :precio_unitario, subtotal = :subtotal WHERE id_detalle_remision = :id_detalle_remision"
+    );
+    $query->execute($datos);
+}
+
+// ELIMINAR DETALLE
+if (isset($_POST['eliminar'])) {
+    $query = $cn->prepare("DELETE FROM detalle_remision WHERE id_detalle_remision = :id");
+    $query->execute(['id' => $_POST['eliminar']]);
+}
+
+// ELIMINAR DETALLES POR REMISION
+if (isset($_POST['eliminar_por_remision'])) {
+    $query = $cn->prepare("DELETE FROM detalle_remision WHERE id_remision = :id");
+    $query->execute(['id' => $_POST['eliminar_por_remision']]);
+}
+
+// LISTAR DETALLES
+if (isset($_POST['leer'])) {
+    $sql =
+        "SELECT d.id_detalle_remision, d.id_remision, d.id_producto, p.nombre AS producto, d.cantidad, d.precio_unitario, d.subtotal FROM detalle_remision d LEFT JOIN productos p ON d.id_producto = p.producto_id";
+    $params = [];
+    if (!empty($_POST['id_remision'])) {
+        $sql .= " WHERE d.id_remision = :id_remision";
+        $params['id_remision'] = $_POST['id_remision'];
+    }
+    $sql .= " ORDER BY d.id_detalle_remision DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $query = $cn->prepare(
+        "SELECT id_detalle_remision, id_remision, id_producto, cantidad, precio_unitario, subtotal FROM detalle_remision WHERE id_detalle_remision = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}
+
+// BUSCAR
+if (isset($_POST['leer_descripcion'])) {
+    $filtro = '%' . $_POST['leer_descripcion'] . '%';
+    $sql =
+        "SELECT d.id_detalle_remision, d.id_remision, d.id_producto, p.nombre AS producto, d.cantidad, d.precio_unitario, d.subtotal FROM detalle_remision d LEFT JOIN productos p ON d.id_producto = p.producto_id WHERE CONCAT(d.id_detalle_remision, p.nombre, d.id_remision) LIKE :filtro";
+    $params = ['filtro' => $filtro];
+    if (!empty($_POST['id_remision'])) {
+        $sql .= " AND d.id_remision = :id_remision";
+        $params['id_remision'] = $_POST['id_remision'];
+    }
+    $sql .= " ORDER BY d.id_detalle_remision DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+?>

--- a/controladores/remision.php
+++ b/controladores/remision.php
@@ -1,0 +1,96 @@
+<?php
+require_once '../conexion/db.php';
+
+// GUARDAR REMISION
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "INSERT INTO remision (id_cliente, fecha_remision, observacion, estado) VALUES (:id_cliente, :fecha_remision, :observacion, :estado)"
+    );
+    $query->execute($datos);
+    echo $cn->lastInsertId();
+}
+
+// ACTUALIZAR REMISION
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "UPDATE remision SET id_cliente = :id_cliente, fecha_remision = :fecha_remision, observacion = :observacion, estado = :estado WHERE id_remision = :id_remision"
+    );
+    $query->execute($datos);
+}
+
+// ELIMINAR REMISION
+if (isset($_POST['eliminar'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare("DELETE FROM remision WHERE id_remision = :id");
+    $query->execute(['id' => $_POST['eliminar']]);
+}
+
+// LEER TODAS LAS REMISIONES
+if (isset($_POST['leer'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "SELECT r.id_remision, r.fecha_remision, r.id_cliente, c.nombre_apellido AS cliente, r.observacion, r.estado, IFNULL(SUM(d.subtotal),0) AS total
+         FROM remision r
+         LEFT JOIN cliente c ON r.id_cliente = c.id_cliente
+         LEFT JOIN detalle_remision d ON r.id_remision = d.id_remision
+         GROUP BY r.id_remision, r.fecha_remision, r.id_cliente, c.nombre_apellido, r.observacion, r.estado
+         ORDER BY r.id_remision DESC"
+    );
+    $query->execute();
+    if ($query->rowCount()) {
+        echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "SELECT r.id_remision, r.fecha_remision, r.id_cliente, c.nombre_apellido AS cliente, r.observacion, r.estado, IFNULL(SUM(d.subtotal),0) AS total
+         FROM remision r
+         LEFT JOIN cliente c ON r.id_cliente = c.id_cliente
+         LEFT JOIN detalle_remision d ON r.id_remision = d.id_remision
+         WHERE r.id_remision = :id
+         GROUP BY r.id_remision, r.fecha_remision, r.id_cliente, c.nombre_apellido, r.observacion, r.estado"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    if ($query->rowCount()) {
+        echo json_encode($query->fetch(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+
+// LEER POR CLIENTE
+if (isset($_POST['leer_descripcion'])) {
+    $f = '%' . $_POST['leer_descripcion'] . '%';
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "SELECT r.id_remision, r.fecha_remision, r.id_cliente, c.nombre_apellido AS cliente, r.observacion, r.estado, IFNULL(SUM(d.subtotal),0) AS total
+         FROM remision r
+         LEFT JOIN cliente c ON r.id_cliente = c.id_cliente
+         LEFT JOIN detalle_remision d ON r.id_remision = d.id_remision
+         WHERE c.nombre_apellido LIKE :filtro
+         GROUP BY r.id_remision, r.fecha_remision, r.id_cliente, c.nombre_apellido, r.observacion, r.estado
+         ORDER BY r.id_remision DESC"
+    );
+    $query->execute(['filtro' => $f]);
+    if ($query->rowCount()) {
+        echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
+    } else {
+        echo '0';
+    }
+}
+?>

--- a/menu.php
+++ b/menu.php
@@ -415,7 +415,7 @@
                 
                   
 <li class="nav-item">
-  <a href="#" class="nav-link" onclick="mostrarListar(); return false;">
+  <a href="#" class="nav-link" onclick="mostrarListarRemision(); return false;">
     <i class="nav-icon bi bi-file-earmark-text"></i>
     <p>Remision</p>
   </a>
@@ -746,6 +746,7 @@
     <script src="vistas/proveedor.js"></script>
     <script src="vistas/cliente.js"></script>
     <script src="vistas/productos.js"></script>
+    <script src="vistas/remision.js"></script>
     <!--end::Script-->
   </body>
   <!--end::Body-->

--- a/paginas/referenciales/remision/agregar.php
+++ b/paginas/referenciales/remision/agregar.php
@@ -1,0 +1,81 @@
+<div class="container mt-4">
+    <input type="hidden" id="id_remision" value="0">
+    <input type="hidden" id="estado_txt" value="PENDIENTE">
+    <div class="card shadow rounded-4">
+        <div class="card-header bg-primary text-white rounded-top-4">
+            <h4 class="mb-0">Agregar / Editar Remisión</h4>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="id_cliente_lst" class="form-label">Cliente</label>
+                    <select id="id_cliente_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-3">
+                    <label for="fecha_txt" class="form-label">Fecha</label>
+                    <input type="date" id="fecha_txt" class="form-control" value="<?php echo date('Y-m-d'); ?>">
+                </div>
+                <div class="col-md-3">
+                    <label for="observacion_txt" class="form-label">Observación</label>
+                    <input type="text" id="observacion_txt" class="form-control">
+                </div>
+            </div>
+            <div class="row g-3 mt-3">
+                <div class="col-md-4">
+                    <label for="id_producto_lst" class="form-label">Producto</label>
+                    <select id="id_producto_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-2">
+                    <label for="cantidad_txt" class="form-label">Cantidad</label>
+                    <input type="number" id="cantidad_txt" class="form-control" min="0">
+                </div>
+                <div class="col-md-2">
+                    <label for="precio_unitario_txt" class="form-label">Precio Unitario</label>
+                    <input type="number" step="0.01" id="precio_unitario_txt" class="form-control">
+                </div>
+                <div class="col-md-2">
+                    <label for="subtotal_txt" class="form-label">Subtotal</label>
+                    <input type="number" step="0.01" id="subtotal_txt" class="form-control" readonly>
+                </div>
+                <div class="col-md-2 d-grid align-items-end">
+                    <button class="btn btn-primary" onclick="agregarDetalleRemision(); return false;">
+                        <i class="bi bi-plus-lg"></i> Agregar Producto
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="card-footer text-end">
+            <button class="btn btn-success me-2" onclick="guardarRemision(); return false;">
+                <i class="bi bi-save"></i> Guardar
+            </button>
+            <button class="btn btn-danger" onclick="mostrarListarRemision(); return false;">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="container mt-4">
+    <div class="table-responsive">
+        <table class="table table-bordered text-center align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>Producto</th>
+                    <th>Cantidad</th>
+                    <th>Precio Unitario</th>
+                    <th>Subtotal</th>
+                    <th>Acción</th>
+                </tr>
+            </thead>
+            <tbody id="detalle_remision_tb">
+            </tbody>
+            <tfoot>
+                <tr>
+                    <th colspan="3" class="text-end">Total</th>
+                    <th id="total_general_txt">0</th>
+                    <th></th>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+</div>

--- a/paginas/referenciales/remision/listar.php
+++ b/paginas/referenciales/remision/listar.php
@@ -1,0 +1,40 @@
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">Listado de Remisiones</h4>
+        <button class="btn btn-primary" onclick="mostrarAgregarRemision(); return false;">
+            <i class="bi bi-plus-circle"></i> Agregar
+        </button>
+    </div>
+    <div class="card shadow-sm rounded-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-8">
+                    <label for="b_remision" class="form-label">Buscador</label>
+                    <input type="text" id="b_remision" class="form-control" placeholder="Buscar por cliente...">
+                </div>
+                <div class="col-md-4">
+                    <button class="btn btn-secondary w-100" onclick="buscarRemision(); return false;">
+                        <i class="bi bi-search"></i> Buscar
+                    </button>
+                </div>
+            </div>
+            <div class="table-responsive mt-4">
+                <table class="table table-bordered table-hover align-middle text-center">
+                    <thead class="table-light">
+                        <tr>
+                            <th>#</th>
+                            <th>Fecha</th>
+                            <th>Cliente</th>
+                            <th>Total</th>
+                            <th>Estado</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="remision_datos_tb">
+                        <!-- Contenido dinámico -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -1,0 +1,228 @@
+let detallesRemision = [];
+let listaClientes = [];
+let listaProductos = [];
+
+function mostrarListarRemision(){
+    let contenido = dameContenido("paginas/referenciales/remision/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaRemision();
+}
+window.mostrarListarRemision = mostrarListarRemision;
+
+function mostrarAgregarRemision(){
+    let contenido = dameContenido("paginas/referenciales/remision/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaClientes();
+    cargarListaProductos();
+    detallesRemision = [];
+    renderDetallesRemision();
+}
+window.mostrarAgregarRemision = mostrarAgregarRemision;
+
+function cargarListaClientes(){
+    let datos = ejecutarAjax("controladores/cliente.php","leer=1");
+    if(datos !== "0"){
+        listaClientes = JSON.parse(datos);
+        renderListaClientes(listaClientes);
+    }
+}
+
+function renderListaClientes(arr){
+    let select = $("#id_cliente_lst");
+    select.html('<option value="">-- Seleccione un cliente --</option>');
+    arr.forEach(c => select.append(`<option value="${c.id_cliente}">${c.nombre_apellido}</option>`));
+}
+
+function cargarListaProductos(){
+    let datos = ejecutarAjax("controladores/productos.php","leerActivo=1");
+    if(datos !== "0"){
+        listaProductos = JSON.parse(datos);
+        renderListaProductos(listaProductos);
+    }
+}
+
+function renderListaProductos(arr){
+    let select = $("#id_producto_lst");
+    select.html('<option value="">-- Seleccione un producto --</option>');
+    arr.forEach(p => select.append(`<option value="${p.producto_id}" data-precio="${p.precio}">${p.nombre}</option>`));
+}
+
+$(document).on('input','#cantidad_txt, #precio_unitario_txt', function(){
+    const cant = parseFloat($('#cantidad_txt').val()) || 0;
+    const precio = parseFloat($('#precio_unitario_txt').val()) || 0;
+    const subtotal = cant * precio;
+    $('#subtotal_txt').val(formatearPY(subtotal));
+});
+
+function agregarDetalleRemision(){
+    if($("#id_producto_lst").val() === ""){mensaje_dialogo_info_ERROR("Debe seleccionar un producto","ERROR");return;}
+    if($("#cantidad_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar la cantidad","ERROR");return;}
+    if($("#precio_unitario_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar el precio","ERROR");return;}
+
+    let detalle = {
+        id_producto: $("#id_producto_lst").val(),
+        producto: $("#id_producto_lst option:selected").text(),
+        cantidad: $("#cantidad_txt").val(),
+        precio_unitario: $("#precio_unitario_txt").val(),
+        subtotal: (parseFloat($("#cantidad_txt").val()) || 0) * (parseFloat($("#precio_unitario_txt").val()) || 0)
+    };
+
+    detallesRemision.push(detalle);
+    renderDetallesRemision();
+    limpiarDetalleRemisionForm();
+}
+window.agregarDetalleRemision = agregarDetalleRemision;
+
+function limpiarDetalleRemisionForm(){
+    $("#id_producto_lst").val("");
+    $("#cantidad_txt").val("");
+    $("#precio_unitario_txt").val("");
+    $("#subtotal_txt").val("");
+}
+
+function renderDetallesRemision(){
+    let tbody = $("#detalle_remision_tb");
+    tbody.html("");
+    let total = 0;
+    detallesRemision.forEach((d,i) => {
+        total += parseFloat(d.subtotal);
+        tbody.append(`<tr>
+            <td>${d.producto}</td>
+            <td>${d.cantidad}</td>
+            <td>${formatearPY(d.precio_unitario)}</td>
+            <td>${formatearPY(d.subtotal)}</td>
+            <td><button class="btn btn-danger btn-sm" onclick="eliminarDetalleRemision(${i}); return false;"><i class="bi bi-trash"></i></button></td>
+        </tr>`);
+    });
+    $("#total_general_txt").text(formatearPY(total));
+}
+
+function eliminarDetalleRemision(index){
+    detallesRemision.splice(index,1);
+    renderDetallesRemision();
+}
+window.eliminarDetalleRemision = eliminarDetalleRemision;
+
+function guardarRemision(){
+    if($("#id_cliente_lst").val() === ""){mensaje_dialogo_info_ERROR("Debe seleccionar un cliente","ERROR");return;}
+    if($("#fecha_txt").val().trim().length===0){mensaje_dialogo_info_ERROR("Debe ingresar la fecha","ERROR");return;}
+    if(detallesRemision.length === 0){mensaje_dialogo_info_ERROR("Debe agregar al menos un producto","ERROR");return;}
+    let datos = {
+        id_cliente: $("#id_cliente_lst").val(),
+        fecha_remision: $("#fecha_txt").val(),
+        observacion: $("#observacion_txt").val(),
+        estado: $("#estado_txt").val()
+    };
+    let idRemision = $("#id_remision").val();
+    if(idRemision === "0"){
+        idRemision = ejecutarAjax("controladores/remision.php","guardar="+JSON.stringify(datos));
+        detallesRemision.forEach(function(d){
+            let det = {...d, id_remision:idRemision};
+            ejecutarAjax("controladores/detalle_remision.php","guardar="+JSON.stringify(det));
+        });
+    }else{
+        datos = {...datos, id_remision:idRemision};
+        ejecutarAjax("controladores/remision.php","actualizar="+JSON.stringify(datos));
+        ejecutarAjax("controladores/detalle_remision.php","eliminar_por_remision="+idRemision);
+        detallesRemision.forEach(function(d){
+            let det = {...d, id_remision:idRemision};
+            ejecutarAjax("controladores/detalle_remision.php","guardar="+JSON.stringify(det));
+        });
+    }
+    mensaje_confirmacion("Guardado correctamente");
+    mostrarListarRemision();
+}
+window.guardarRemision = guardarRemision;
+
+function cargarTablaRemision(){
+    let datos = ejecutarAjax("controladores/remision.php","leer=1");
+    if(datos === "0"){
+        $("#remision_datos_tb").html("NO HAY REGISTROS");
+    }else{
+        let json = JSON.parse(datos);
+        $("#remision_datos_tb").html("");
+        json.map(function(it){
+            $("#remision_datos_tb").append(`
+                <tr>
+                    <td>${it.id_remision}</td>
+                    <td>${it.fecha_remision}</td>
+                    <td>${it.cliente}</td>
+                    <td>${formatearPY(it.total)}</td>
+                    <td>${badgeEstado(it.estado)}</td>
+                    <td>
+                        <button class="btn btn-warning btn-sm editar-remision" title="Editar"><i class="bi bi-pencil-square"></i></button>
+                        <button class="btn btn-danger btn-sm eliminar-remision" title="Eliminar"><i class="bi bi-trash"></i></button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+
+function buscarRemision(){
+    let b = $("#b_remision").val();
+    let datos = ejecutarAjax("controladores/remision.php","leer_descripcion="+b);
+    if(datos === "0"){
+        $("#remision_datos_tb").html("NO HAY REGISTROS");
+    }else{
+        let json = JSON.parse(datos);
+        $("#remision_datos_tb").html("");
+        json.map(function(it){
+            $("#remision_datos_tb").append(`
+                <tr>
+                    <td>${it.id_remision}</td>
+                    <td>${it.fecha_remision}</td>
+                    <td>${it.cliente}</td>
+                    <td>${formatearPY(it.total)}</td>
+                    <td>${badgeEstado(it.estado)}</td>
+                    <td>
+                        <button class="btn btn-warning btn-sm editar-remision" title="Editar"><i class="bi bi-pencil-square"></i></button>
+                        <button class="btn btn-danger btn-sm eliminar-remision" title="Eliminar"><i class="bi bi-trash"></i></button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+window.buscarRemision = buscarRemision;
+
+$(document).on("click",".editar-remision",function(){
+    let id=$(this).closest("tr").find("td:eq(0)").text();
+    mostrarAgregarRemision();
+    setTimeout(function(){
+        let datos=ejecutarAjax("controladores/remision.php","leer_id="+id);
+        let json=JSON.parse(datos);
+        $("#id_remision").val(json.id_remision);
+        $("#id_cliente_lst").val(json.id_cliente);
+        $("#fecha_txt").val(json.fecha_remision);
+        $("#observacion_txt").val(json.observacion);
+        $("#estado_txt").val(json.estado);
+        let det=ejecutarAjax("controladores/detalle_remision.php","leer=1&id_remision="+id);
+        if(det !== "0"){
+            detallesRemision=JSON.parse(det).map(d=>({id_producto:d.id_producto,producto:d.producto,cantidad:d.cantidad,precio_unitario:d.precio_unitario,subtotal:d.subtotal}));
+        }else{
+            detallesRemision=[];
+        }
+        renderDetallesRemision();
+    },100);
+});
+
+$(document).on("click",".eliminar-remision",function(){
+    let id=$(this).closest("tr").find("td:eq(0)").text();
+    Swal.fire({
+        title:"¿Estás seguro?",
+        text:"Esta acción no se puede deshacer.",
+        icon:"warning",
+        showCancelButton:true,
+        confirmButtonText:"Sí, eliminar",
+        cancelButtonText:"Cancelar",
+        confirmButtonColor:"#dc3545",
+        cancelButtonColor:"#6c757d",
+        reverseButtons:true
+    }).then((result)=>{
+        if(result.isConfirmed){
+            ejecutarAjax("controladores/remision.php","eliminar="+id);
+            ejecutarAjax("controladores/detalle_remision.php","eliminar_por_remision="+id);
+            mensaje_confirmacion("Eliminado correctamente");
+            cargarTablaRemision();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add Remisión module with form to register product deliveries to clients
- support dynamic product rows with subtotal and total calculation and default PENDIENTE state
- create backend controllers and menu link for managing remisiones

## Testing
- `php -l controladores/remision.php`
- `php -l controladores/detalle_remision.php`
- `php -l paginas/referenciales/remision/agregar.php`
- `php -l paginas/referenciales/remision/listar.php`
- `node --check vistas/remision.js`


------
https://chatgpt.com/codex/tasks/task_e_688fff6b4a748325bdaa1737ec8da706