### PR TITLE
Add status filter to purchase budgets list

### DIFF
--- a/controladores/presupuestos_compra.php
+++ b/controladores/presupuestos_compra.php
@@ -84,11 +84,19 @@ if (isset($_POST['leer_id'])) {
 // LEER POR DESCRIPCION
 if (isset($_POST['leer_descripcion'])) {
     $f = '%' . $_POST['leer_descripcion'] . '%';
+    $estado = $_POST['estado'] ?? '';
     $db = new DB();
-    $query = $db->conectar()->prepare(
-        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE CONCAT(p.id_presupuesto, pr.razon_social) LIKE :filtro ORDER BY p.id_presupuesto DESC"
-    );
-    $query->execute(['filtro' => $f]);
+    $sql = "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE CONCAT(p.id_presupuesto, pr.razon_social) LIKE :filtro";
+    if ($estado !== '') {
+        $sql .= " AND p.estado = :estado";
+    }
+    $sql .= " ORDER BY p.id_presupuesto DESC";
+    $query = $db->conectar()->prepare($sql);
+    $params = ['filtro' => $f];
+    if ($estado !== '') {
+        $params['estado'] = $estado;
+    }
+    $query->execute($params);
     if ($query->rowCount()) {
         echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
     } else {

--- a/paginas/referenciales/presupuestos_compra/listar.php
+++ b/paginas/referenciales/presupuestos_compra/listar.php
@@ -14,11 +14,20 @@
         <div class="card-body">
             <!-- Buscador -->
             <div class="row g-3 align-items-end mb-3">
-                <div class="col-md-8">
+                <div class="col-md-5">
                     <label for="b_presupuesto" class="form-label fw-semibold">Buscar presupuesto</label>
                     <input type="text" id="b_presupuesto" class="form-control form-control-lg" placeholder="Escribe el nombre del proveedor...">
                 </div>
                 <div class="col-md-4">
+                    <label for="estado_filtro" class="form-label fw-semibold">Estado</label>
+                    <select id="estado_filtro" class="form-select form-select-lg">
+                        <option value="">Todos</option>
+                        <option value="PENDIENTE">Pendientes</option>
+                        <option value="APROBADO">Aprobados</option>
+                        <option value="ANULADO">Anulados</option>
+                    </select>
+                </div>
+                <div class="col-md-3">
                     <button class="btn btn-outline-primary btn-lg w-100 shadow-sm" onclick="buscarPresupuesto(); return false;">
                         <i class="bi bi-search me-2"></i> Buscar
                     </button>

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -265,8 +265,15 @@ $(document).on("keyup","#b_presupuesto",function(){
     buscarPresupuesto();
 });
 
+$(document).on("change","#estado_filtro",function(){
+    buscarPresupuesto();
+});
+
 function buscarPresupuesto(){
-    let datos = ejecutarAjax("controladores/presupuestos_compra.php","leer_descripcion="+$("#b_presupuesto").val());
+    let datos = ejecutarAjax(
+        "controladores/presupuestos_compra.php",
+        "leer_descripcion="+$("#b_presupuesto").val()+"&estado="+$("#estado_filtro").val()
+    );
     if(datos === "0"){
         $("#datos_tb").html("NO HAY REGISTROS");
     }else{


### PR DESCRIPTION
## Summary
- add state dropdown next to purchase budget search
- filter budgets by selected status via JS and controller

## Testing
- `php -l controladores/presupuestos_compra.php`
- `php -l paginas/referenciales/presupuestos_compra/listar.php`
- `node --check vistas/presupuestos_compra.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689016811e98832586a53c697118e91a