### PR TITLE
Add type filter for products

### DIFF
--- a/controladores/productos.php
+++ b/controladores/productos.php
@@ -49,12 +49,20 @@ if (isset($_POST['leerActivo'])) {
 
 if (isset($_POST['leer_descripcion'])) {
     $filtro = '%' . $_POST['leer_descripcion'] . '%';
-    $query = $db->prepare(
+    $tipo = $_POST['tipo'] ?? '';
+    $sql =
         "SELECT producto_id, nombre, descripcion, precio, tipo, estado " .
-        "FROM productos WHERE CONCAT(producto_id, nombre, descripcion, precio, tipo, estado) LIKE :filtro " .
-        "ORDER BY producto_id DESC"
-    );
-    $query->execute(['filtro' => $filtro]);
+        "FROM productos WHERE CONCAT(producto_id, nombre, descripcion, precio, tipo, estado) LIKE :filtro";
+    if ($tipo !== '') {
+        $sql .= " AND tipo = :tipo";
+    }
+    $sql .= " ORDER BY producto_id DESC";
+    $query = $db->prepare($sql);
+    $params = ['filtro' => $filtro];
+    if ($tipo !== '') {
+        $params['tipo'] = $tipo;
+    }
+    $query->execute($params);
     echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
 

--- a/paginas/referenciales/productos/listar.php
+++ b/paginas/referenciales/productos/listar.php
@@ -14,13 +14,21 @@
     <div class="card border-0 bg-light bg-opacity-75 rounded-4 shadow-sm mb-4">
       <div class="card-body">
         <div class="row g-3 align-items-end">
-          <div class="col-md-8">
+          <div class="col-md-5">
             <label for="b_producto" class="form-label fw-semibold">
               <i class="bi bi-search me-2"></i> Buscar producto
             </label>
-            <input type="text" id="b_producto" class="form-control form-control-lg" placeholder="Buscar por nombre, tipo o estado...">
+            <input type="text" id="b_producto" class="form-control form-control-lg" placeholder="Buscar por nombre o estado...">
           </div>
           <div class="col-md-4">
+            <label for="tipo_filtro" class="form-label fw-semibold">Tipo</label>
+            <select id="tipo_filtro" class="form-select form-select-lg">
+              <option value="">Todos</option>
+              <option value="PRODUCTO">Producto</option>
+              <option value="SERVICIO">Servicio</option>
+            </select>
+          </div>
+          <div class="col-md-3">
             <button class="btn btn-outline-primary btn-lg w-100 shadow-sm" onclick="buscarProducto(); return false;">
               <i class="bi bi-search me-2"></i> Buscar
             </button>

--- a/vistas/productos.js
+++ b/vistas/productos.js
@@ -123,8 +123,12 @@ $(document).on("keyup","#b_producto",function(){
     buscarProducto();
 });
 
+$(document).on("change","#tipo_filtro",function(){
+    buscarProducto();
+});
+
 function buscarProducto(){
-    let datos=ejecutarAjax("controladores/productos.php","leer_descripcion="+$("#b_producto").val());
+    let datos=ejecutarAjax("controladores/productos.php","leer_descripcion="+$("#b_producto").val()+"&tipo="+$("#tipo_filtro").val());
     if(datos === "0"){
         $("#datos_tb").html("NO HAY REGISTROS");
     }else{


### PR DESCRIPTION
## Summary
- add dropdown filter to list products by type
- support filtering products by type in search

## Testing
- `php -l controladores/productos.php`
- `php -l paginas/referenciales/productos/listar.php`


------
https://chatgpt.com/codex/tasks/task_e_6890189f5bc08325b388a91523981f92