### PR TITLE
Enable editing, annulling and printing purchase orders

### DIFF
--- a/controladores/orden_compra.php
+++ b/controladores/orden_compra.php
@@ -40,6 +40,13 @@ if (isset($_POST['eliminar'])) {
     $query->execute(['id' => $_POST['eliminar']]);
 }
 
+// ANULAR ORDEN
+if (isset($_POST['anular'])) {
+    $db = new DB();
+    $query = $db->conectar()->prepare("UPDATE orden_compra SET estado = 'ANULADO' WHERE id_orden = :id");
+    $query->execute(['id' => $_POST['anular']]);
+}
+
 // LEER TODAS LAS ORDENES
 if (isset($_POST['leer'])) {
     $db = new DB();
@@ -71,6 +78,7 @@ if (isset($_POST['leer_id'])) {
      FROM orden_compra o
      LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor
      LEFT JOIN detalle_orden_compra d ON o.id_orden = d.id_orden
+     WHERE o.id_orden = :id
      GROUP BY o.id_orden, o.fecha_emision, o.id_presupuesto, 
               o.id_proveedor, pr.razon_social, o.estado
      ORDER BY o.id_orden DESC"


### PR DESCRIPTION
## Summary
- Allow loading and editing of existing purchase orders with their associated data.
- Replace deletion with annulling, marking orders as ANULADO when cancelled.
- Add per-order print action from the orders list.

## Testing
- `php -l controladores/orden_compra.php`
- `node --check vistas/orden_compra.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68911da8eac483259e4a72870aaa5ede