### PR TITLE
Permitir eliminar productos al editar orden de compra

### DIFF
--- a/controladores/detalle_presupuesto.php
+++ b/controladores/detalle_presupuesto.php
@@ -31,6 +31,15 @@ if (isset($_POST['eliminar'])) {
     $query->execute(['id' => $_POST['eliminar']]);
 }
 
+// ELIMINAR DETALLE POR PRESUPUESTO Y PRODUCTO
+if (isset($_POST['eliminar_producto'])) {
+    $datos = json_decode($_POST['eliminar_producto'], true);
+    $query = $cn->prepare(
+        "DELETE FROM detalle_presupuesto WHERE id_presupuesto = :id_presupuesto AND id_producto = :id_producto"
+    );
+    $query->execute($datos);
+}
+
 // LISTAR DETALLES
 if (isset($_POST['leer'])) {
     $sql =

--- a/paginas/referenciales/orden_compra/agregar.php
+++ b/paginas/referenciales/orden_compra/agregar.php
@@ -78,6 +78,7 @@
                             <th>Cantidad</th>
                             <th>Precio Unitario</th>
                             <th>Subtotal</th>
+                            <th>Acción</th>
                         </tr>
                     </thead>
                     <tbody id="detalle_oc_tb">


### PR DESCRIPTION
## Summary
- Agrega columna de acción y botón para eliminar productos en la edición de órdenes de compra
- Sincroniza la eliminación con el presupuesto asociado, actualizando detalle y total

## Testing
- `php -l controladores/detalle_presupuesto.php`
- `php -l paginas/referenciales/orden_compra/agregar.php`
- `node --check vistas/orden_compra.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_6891220dabc4832594f9741ada4a73ee