### PR TITLE
Evitar registros duplicados de RUC en proveedores

### DIFF
--- a/controladores/proveedor.php
+++ b/controladores/proveedor.php
@@ -6,21 +6,44 @@ $db = $base_datos->conectar();
 
 if (isset($_POST['guardar'])) {
     $datos = json_decode($_POST['guardar'], true);
+
+    // Verificar si el RUC ya existe
+    $query = $db->prepare("SELECT COUNT(*) FROM proveedor WHERE ruc = :ruc");
+    $query->execute(['ruc' => $datos['ruc']]);
+    if ($query->fetchColumn() > 0) {
+        echo 'duplicado';
+        return;
+    }
+
     $query = $db->prepare(
         "INSERT INTO proveedor (razon_social, ruc, direccion, id_ciudad, telefono, estado) " .
         "VALUES (:razon_social, :ruc, :direccion, :id_ciudad, :telefono, :estado)"
     );
     $query->execute($datos);
+    echo 'ok';
 }
 
 if (isset($_POST['actualizar'])) {
     $datos = json_decode($_POST['actualizar'], true);
+
+    // Verificar si el RUC ya existe para otro proveedor
+    $query = $db->prepare("SELECT COUNT(*) FROM proveedor WHERE ruc = :ruc AND id_proveedor <> :id_proveedor");
+    $query->execute([
+        'ruc' => $datos['ruc'],
+        'id_proveedor' => $datos['id_proveedor']
+    ]);
+    if ($query->fetchColumn() > 0) {
+        echo 'duplicado';
+        return;
+    }
+
     $query = $db->prepare(
         "UPDATE proveedor SET razon_social = :razon_social, ruc = :ruc, " .
         "direccion = :direccion, id_ciudad = :id_ciudad, telefono = :telefono, estado = :estado " .
         "WHERE id_proveedor = :id_proveedor"
     );
     $query->execute($datos);
+    echo 'ok';
 }
 
 if (isset($_POST['eliminar'])) {

--- a/utcdp1.sql
+++ b/utcdp1.sql
@@ -198,7 +198,7 @@ INSERT INTO `producto` (`id_producto`, `nombre`, `descripcion`, `precio`, `stock
 CREATE TABLE `proveedor` (
   `id_proveedor` int(11) NOT NULL,
   `razon_social` varchar(100) NOT NULL,
-  `ruc` varchar(50) NOT NULL,
+  `ruc` varchar(50) NOT NULL UNIQUE,
   `direccion` varchar(150) NOT NULL,
   `id_ciudad` int(11) NOT NULL,
   `telefono` varchar(50) NOT NULL,

--- a/vistas/proveedor.js
+++ b/vistas/proveedor.js
@@ -138,14 +138,22 @@ function guardarProveedor(){
         estado: $("#estado_lst").val()
     };
 
-    if($("#id_proveedor").val()==="0"){
+    if($("#id_proveedor").val()==="0"){ 
         let res = ejecutarAjax("controladores/proveedor.php","guardar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("El RUC ya se encuentra registrado", "ATENCION");
+            return;
+        }
         mensaje_dialogo_correcto("Guardado correctamente", 'GUARDADO');
         mostrarListarProveedor();
         limpiarProveedor();
     }else{
         datos = {...datos, id_proveedor: $("#id_proveedor").val()};
         let res = ejecutarAjax("controladores/proveedor.php","actualizar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("El RUC ya se encuentra registrado", "ATENCION");
+            return;
+        }
         mensaje_dialogo_correcto("Actualizado correctamente", 'ACTUALIZADO');
         mostrarListarProveedor();
         limpiarProveedor();


### PR DESCRIPTION
## Summary
- verify RUC uniqueness when creating or updating proveedores
- alert frontend when duplicate RUC is detected
- add unique constraint for RUC in SQL schema

## Testing
- `php -l controladores/proveedor.php`
- `node --check vistas/proveedor.js`


------
https://chatgpt.com/codex/tasks/task_e_68915b51ffb08325b7cc1af78a6a9a33