### PR TITLE
Prevent duplicate client RUCs

### DIFF
--- a/controladores/cliente.php
+++ b/controladores/cliente.php
@@ -5,7 +5,8 @@ $base_datos = new DB();
 $db = $base_datos->conectar();
 
 if (isset($_POST['guardar'])) {
-    $datos = json_decode($_POST['guardar'], true);
+    // Limpiar espacios en blanco
+    $datos = array_map('trim', json_decode($_POST['guardar'], true));
 
     // Verificar si el RUC ya existe
     $query = $db->prepare("SELECT COUNT(*) FROM clientes WHERE ruc = :ruc");
@@ -24,7 +25,8 @@ if (isset($_POST['guardar'])) {
 }
 
 if (isset($_POST['actualizar'])) {
-    $datos = json_decode($_POST['actualizar'], true);
+    // Limpiar espacios en blanco
+    $datos = array_map('trim', json_decode($_POST['actualizar'], true));
 
     // Verificar si el RUC ya existe para otro cliente
     $query = $db->prepare("SELECT COUNT(*) FROM clientes WHERE ruc = :ruc AND id_cliente <> :id_cliente");

--- a/vistas/cliente.js
+++ b/vistas/cliente.js
@@ -113,22 +113,30 @@ function guardarCliente(){
     }
 
     let datos={
-        nombre_apellido: $("#nombre_txt").val(),
-        ruc: $("#ruc_txt").val(),
-        direccion: $("#direccion_txt").val(),
+        nombre_apellido: $("#nombre_txt").val().trim(),
+        ruc: $("#ruc_txt").val().trim(),
+        direccion: $("#direccion_txt").val().trim(),
         id_ciudad: $("#ciudad_lst").val(),
-        telefono: $("#telefono_txt").val(),
+        telefono: $("#telefono_txt").val().trim(),
         estado: $("#estado_lst").val()
     };
 
     if($("#id_cliente").val()==="0"){
         let res = ejecutarAjax("controladores/cliente.php","guardar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("El RUC ya existe", "ATENCION");
+            return;
+        }
         mensaje_confirmacion("Guardado correctamente");
         mostrarListarCliente();
         limpiarCliente();
     }else{
         datos = {...datos, id_cliente: $("#id_cliente").val()};
         let res = ejecutarAjax("controladores/cliente.php","actualizar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("El RUC ya existe", "ATENCION");
+            return;
+        }
         mensaje_confirmacion("Actualizado correctamente");
         mostrarListarCliente();
         limpiarCliente();


### PR DESCRIPTION
## Summary
- Trim client fields on save/update and enforce duplicate RUC checks in the controller
- Sanitize client form inputs and handle duplicate RUC responses on the frontend

## Testing
- `php -l controladores/cliente.php`
- `node --check vistas/cliente.js`


------
https://chatgpt.com/codex/tasks/task_e_68915e6582fc8325998371aa2bf7aacc