### PR TITLE
Validar ciudades duplicadas y corregir buscador

### DIFF
--- a/controladores/ciudad.php
+++ b/controladores/ciudad.php
@@ -1,122 +1,84 @@
 <?php
 require_once '../conexion/db.php';
 
-if(isset($_POST['guardar'])){
-    //se convierte en un arreglo
-    $json_datos = json_decode($_POST['guardar'], true);
-    //se crea un objeto de conexion
-    $base_datos = new DB();
-    //preparamos la insercion
-    $query = $base_datos->conectar()->prepare("INSERT INTO ciudad"
-            . "( descripcion, id_departamento, estado) VALUES (:descripcion, :id_departamento, :estado)");
-    
-    $query->execute($json_datos);
-    
+$base_datos = new DB();
+$db = $base_datos->conectar();
+
+if (isset($_POST['guardar'])) {
+    $datos = array_map('trim', json_decode($_POST['guardar'], true));
+
+    // Verificar si la ciudad ya existe (ignorando mayúsculas/minúsculas)
+    $query = $db->prepare("SELECT COUNT(*) FROM ciudad WHERE LOWER(TRIM(descripcion)) = LOWER(:descripcion)");
+    $query->execute(['descripcion' => $datos['descripcion']]);
+    if ($query->fetchColumn() > 0) {
+        echo 'duplicado';
+        return;
+    }
+
+    $query = $db->prepare(
+        "INSERT INTO ciudad (descripcion, id_departamento, estado) " .
+        "VALUES (:descripcion, :id_departamento, :estado)"
+    );
+    $query->execute($datos);
+    echo 'ok';
 }
-//--------------------------------------------------------------
-//--------------------------------------------------------------
-//--------------------------------------------------------------
-if(isset($_POST['actualizar'])){
-    //se convierte en un arreglo
-    $json_datos = json_decode($_POST['actualizar'], true);
-    //se crea un objeto de conexion
-    $base_datos = new DB();
-    //preparamos la insercion
-    $query = $base_datos->conectar()->prepare("UPDATE ciudad SET "
-            . " descripcion = :descripcion, id_departamento = :id_departamento, estado = :estado "
-            . "where id_ciudad = :id_ciudad");
-    
-    $query->execute($json_datos);
-    
-}
-//--------------------------------------------------------------
-//--------------------------------------------------------------
-//--------------------------------------------------------------
-if(isset($_POST['eliminar'])){
-    //se convierte en un arreglo
-    //se crea un objeto de conexion
-    $base_datos = new DB();
-    //preparamos la insercion
-    $query = $base_datos->conectar()->prepare("DELETE FROM ciudad "
-            . " WHERE id_ciudad = :id_ciudad");
-    
+
+if (isset($_POST['actualizar'])) {
+    $datos = array_map('trim', json_decode($_POST['actualizar'], true));
+
+    // Verificar si la ciudad ya existe para otro registro
+    $query = $db->prepare(
+        "SELECT COUNT(*) FROM ciudad WHERE LOWER(TRIM(descripcion)) = LOWER(:descripcion) AND id_ciudad <> :id_ciudad"
+    );
     $query->execute([
-        "id_ciudad" => $_POST['eliminar']
+        'descripcion' => $datos['descripcion'],
+        'id_ciudad' => $datos['id_ciudad']
     ]);
-    
+    if ($query->fetchColumn() > 0) {
+        echo 'duplicado';
+        return;
+    }
+
+    $query = $db->prepare(
+        "UPDATE ciudad SET descripcion = :descripcion, id_departamento = :id_departamento, estado = :estado " .
+        "WHERE id_ciudad = :id_ciudad"
+    );
+    $query->execute($datos);
+    echo 'ok';
 }
-//------------------------------------------------------------
-//------------------------------------------------------------
-//------------------------------------------------------------
-if(isset($_POST['leer'])){
-    $base_datos = new DB();
-    $query = $base_datos->conectar()->prepare(
-            "SELECT
-c.id_ciudad,
-c.descripcion,
-d.descripcion as departamentos,
-c.estado
-FROM ciudad c 
-JOIN departamentos d 
-ON d.id_departamento = c.id_departamento;");
-    
+
+if (isset($_POST['eliminar'])) {
+    $query = $db->prepare("DELETE FROM ciudad WHERE id_ciudad = :id_ciudad");
+    $query->execute(['id_ciudad' => $_POST['eliminar']]);
+}
+
+if (isset($_POST['leer'])) {
+    $query = $db->prepare(
+        "SELECT c.id_ciudad, c.descripcion, d.descripcion AS departamentos, c.estado " .
+        "FROM ciudad c JOIN departamentos d ON d.id_departamento = c.id_departamento"
+    );
     $query->execute();
-    
-    if($query->rowCount()){
-        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
-    }else{
-        echo "0";
-    }
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
-//------------------------------------------------------------
-//------------------------------------------------------------
-//------------------------------------------------------------
-if(isset($_POST['leer_descripcion'])){
-    $base_datos = new DB();
-    $query = $base_datos->conectar()->prepare(
-            "SELECT
-c.id_ciudad,
-c.descripcion,
-d.descripcion as departamentos,
-c.estado
-FROM ciudad c
-JOIN departamentos d
-ON d.id_departamento = c.id_departamento
-where concat(c.id_ciudad,
-c.descripcion,
-d.descripcion,
-c.estado) Like '%".$_POST['leer_descripcion']."%' ");
-    
-    $query->execute();
-    
-    if($query->rowCount()){
-        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
-    }else{
-        echo "0";
-    }
-}//------------------------------------------------------------
-//------------------------------------------------------------
-//------------------------------------------------------------
-if(isset($_POST['leer_id'])){
-    $base_datos = new DB();
-    $query = $base_datos->conectar()->prepare(
-        "SELECT 
-            c.id_ciudad, 
-            c.descripcion, 
-            c.estado, 
-            d.descripcion AS departamentos,
-            c.id_departamento
-         FROM ciudad c
-         JOIN departamentos d ON c.id_departamento = d.id_departamento
-         WHERE c.id_ciudad = :id");
-    
-    $query->execute([
-        "id" => $_POST['leer_id']
-    ]);
-    
-    if($query->rowCount()){
-        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
-    }else{
-        echo "0";
-    }
+
+if (isset($_POST['leer_descripcion'])) {
+    $filtro = '%' . $_POST['leer_descripcion'] . '%';
+    $query = $db->prepare(
+        "SELECT c.id_ciudad, c.descripcion, d.descripcion AS departamentos, c.estado " .
+        "FROM ciudad c JOIN departamentos d ON d.id_departamento = c.id_departamento " .
+        "WHERE CONCAT(c.id_ciudad, c.descripcion, d.descripcion, c.estado) LIKE :filtro"
+    );
+    $query->execute(['filtro' => $filtro]);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
+
+if (isset($_POST['leer_id'])) {
+    $query = $db->prepare(
+        "SELECT c.id_ciudad, c.descripcion, c.estado, d.descripcion AS departamentos, c.id_departamento " .
+        "FROM ciudad c JOIN departamentos d ON c.id_departamento = d.id_departamento " .
+        "WHERE c.id_ciudad = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}
+

--- a/vistas/ciudad.js
+++ b/vistas/ciudad.js
@@ -101,6 +101,10 @@ function guardarCiudad(){
 
         let res = ejecutarAjax("controladores/ciudad.php",
         "guardar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("La ciudad ya existe", "ERROR");
+            return;
+        }
         console.log(res);
         mensaje_dialogo_correcto("Guardado correctamente", "GUARDADO");
         mostrarListarCiudad();
@@ -110,6 +114,10 @@ function guardarCiudad(){
 
         let res = ejecutarAjax("controladores/ciudad.php",
         "actualizar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("La ciudad ya existe", "ERROR");
+            return;
+        }
         console.log(res);
         mensaje_dialogo_correcto("Actualizado correctamente", "ACTUALIZADO");
         mostrarListarCiudad();
@@ -253,7 +261,7 @@ $(document).on("keyup", "#b_ciudad", function (evt) {
                             <b style="font-size: 17px;">${item.descripcion}</b>
                         </div>
                         <div class="col-8">
-                            <i>${item.departamento}</i>
+                            <i>${item.departamentos}</i>
                         </div>
                         <div class="col-4">
                             ${badgeEstado(item.estado)}


### PR DESCRIPTION
## Summary
- Evita guardar o actualizar ciudades con nombres duplicados sin importar mayúsculas o minúsculas.
- Corrige el buscador de ciudades para mostrar el departamento correspondiente.

## Testing
- `php -l controladores/ciudad.php`
- `node --check vistas/ciudad.js`


------
https://chatgpt.com/codex/tasks/task_e_6892147f5afc8325b2ec1eee57fd8ed5