### PR TITLE
Evitar descripciones duplicadas en departamentos

### DIFF
--- a/vistas/departamento.js
+++ b/vistas/departamento.js
@@ -31,23 +31,31 @@ function guardarDepartamento(){
     
     console.log(datos);
     if($("#id_departamento").val() === "0"){
-        
-        let res =  ejecutarAjax("controladores/departamento.php", 
+
+        let res =  ejecutarAjax("controladores/departamento.php",
         "guardar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("El departamento ya existe", "ERROR");
+            return;
+        }
         console.log(res);
-        alert("Guardado correctamente");
+        mensaje_dialogo_correcto("Guardado correctamente", "GUARDADO");
         mostrarListarDepartamento();
         limpiarDepartamento();
     }else{
         datos = {...datos, "id_departamento" : $("#id_departamento").val()};
-        
-        let res =  ejecutarAjax("controladores/departamento.php", 
+
+        let res =  ejecutarAjax("controladores/departamento.php",
         "actualizar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("El departamento ya existe", "ERROR");
+            return;
+        }
         console.log(res);
-        alert("Actualizado correctamente");
+        mensaje_dialogo_correcto("Actualizado correctamente", "ACTUALIZADO");
         mostrarListarDepartamento();
         limpiarDepartamento();
-        
+
     }
     
 }


### PR DESCRIPTION
## Summary
- Valida en el servidor si un departamento ya existe antes de guardar o actualizar
- Muestra un mensaje de error en la interfaz cuando la descripción del departamento está duplicada

## Testing
- `php -l controladores/departamento.php`
- `node --check vistas/departamento.js`


------
https://chatgpt.com/codex/tasks/task_e_689216a3127c8325b54dff5cd9f9f282