### PR TITLE
Move total estimate field and make read-only

### DIFF
--- a/paginas/referenciales/presupuestos_compra/agregar.php
+++ b/paginas/referenciales/presupuestos_compra/agregar.php
@@ -31,12 +31,6 @@
                     <select id="id_producto_lst" class="form-select"></select>
                 </div>
 
-                <!-- Total estimado -->
-                <div class="col-md-6">
-                    <label for="total_txt" class="form-label fw-semibold">Total Estimado</label>
-                    <input type="number" step="0.01" id="total_txt" class="form-control" placeholder="0.00">
-                </div>
-
                 <!-- Cantidad -->
                 <div class="col-md-3">
                     <label for="cantidad_txt" class="form-label fw-semibold">Cantidad</label>
@@ -98,6 +92,16 @@
                     </tbody>
                 </table>
             </div>
+        </div>
+    </div>
+</div>
+
+<!-- Total estimado -->
+<div class="container mt-3">
+    <div class="row justify-content-end">
+        <div class="col-md-3">
+            <label for="total_txt" class="form-label fw-semibold">Total Estimado</label>
+            <input type="number" step="0.01" id="total_txt" class="form-control bg-light" placeholder="0.00" readonly>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Move total estimate input beneath the product detail table
- Make the total estimate field read-only so users cannot modify it manually

## Testing
- `php -l paginas/referenciales/presupuestos_compra/agregar.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895288e5100832590e0b5e5b14ad28c