### PR TITLE
Evita duplicado de productos en orden de compra

### DIFF
--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -95,8 +95,14 @@ function agregarProductoExtra(){
     if($("#cantidad_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar la cantidad","ERROR");return;}
     if($("#precio_unitario_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar el costo","ERROR");return;}
 
+    let idProducto = $("#id_producto_lst").val();
+    if(detallesOC.some(d => d.id_producto === idProducto)){
+        mensaje_dialogo_info_ERROR("El producto ya está cargado","ERROR");
+        return;
+    }
+
     let detalle = {
-        id_producto: $("#id_producto_lst").val(),
+        id_producto: idProducto,
         producto: $("#id_producto_lst option:selected").text(),
         cantidad: $("#cantidad_txt").val(),
         precio_unitario: $("#precio_unitario_txt").val(),


### PR DESCRIPTION
## Summary
- Impide que se agreguen productos repetidos en la orden de compra

## Testing
- `node --check vistas/orden_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_68952c40614c832584f31f68639d7472