### PR TITLE
Fix duplicate product validation in budgets and orders

### DIFF
--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -73,8 +73,8 @@ $(document).on('change','#id_presupuesto_lst',function(){
        $("#proveedor_txt").val(p.proveedor || p.id_proveedor);
        $("#id_proveedor").val(p.id_proveedor);
        let det = ejecutarAjax("controladores/detalle_presupuesto.php","leer=1&id_presupuesto="+id);
-       if(det !== "0"){
-           detallesOC = JSON.parse(det).map(d => ({id_producto:d.id_producto,producto:d.producto,cantidad:d.cantidad,precio_unitario:d.precio_unitario,subtotal:d.subtotal}));
+       if(det !== "0"){       
+           detallesOC = JSON.parse(det).map(d => ({id_producto: parseInt(d.id_producto), producto:d.producto, cantidad:d.cantidad, precio_unitario:d.precio_unitario, subtotal:d.subtotal}));
        }else{
            detallesOC = [];
        }
@@ -95,7 +95,7 @@ function agregarProductoExtra(){
     if($("#cantidad_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar la cantidad","ERROR");return;}
     if($("#precio_unitario_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar el costo","ERROR");return;}
 
-    let idProducto = $("#id_producto_lst").val();
+    let idProducto = parseInt($("#id_producto_lst").val());
     if(detallesOC.some(d => d.id_producto === idProducto)){
         mensaje_dialogo_info_ERROR("El producto ya está cargado","ERROR");
         return;
@@ -390,8 +390,8 @@ $(document).on('click','.editar-orden',function(){
     $("#id_proveedor").val(json.id_proveedor);
     $("#fecha_txt").val(json.fecha_emision);
     let det = ejecutarAjax("controladores/detalle_orden_compra.php","leer=1&id_orden="+id);
-    if(det !== "0"){
-        detallesOC = JSON.parse(det).map(d => ({id_producto:d.id_producto,producto:d.producto,cantidad:d.cantidad,precio_unitario:d.precio_unitario,subtotal:d.subtotal}));
+    if(det !== "0"){       
+        detallesOC = JSON.parse(det).map(d => ({id_producto: parseInt(d.id_producto), producto:d.producto, cantidad:d.cantidad, precio_unitario:d.precio_unitario, subtotal:d.subtotal}));
         renderDetallesOC();
     }
 });

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -79,7 +79,7 @@ function agregarDetalle(){
         return;
     }
 
-    let idProducto = $("#id_producto_lst").val();
+    let idProducto = parseInt($("#id_producto_lst").val());
     if(detalles.some(d => d.id_producto === idProducto)){
         mensaje_dialogo_info_ERROR("El producto ya está cargado", "ERROR");
         return;
@@ -237,7 +237,7 @@ $(document).on("click",".editar-presupuesto",function(){
     // Cargar datos del detalle asociado
     let det = ejecutarAjax("controladores/detalle_presupuesto.php","leer=1&id_presupuesto="+id);
     if(det !== "0"){
-        detalles = JSON.parse(det);
+        detalles = JSON.parse(det).map(d => ({...d, id_producto: parseInt(d.id_producto)}));
         renderDetalles();
     }
 });


### PR DESCRIPTION
## Summary
- ensure product IDs are numeric before checking for duplicates
- parse product IDs when loading existing details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952e694f2c83259ee3f5c339c39826