### PR TITLE
Ensure remision product price is non-zero

### DIFF
--- a/controladores/detalle_remision.php
+++ b/controladores/detalle_remision.php
@@ -8,9 +8,14 @@ $cn = $db->conectar();
 if (isset($_POST['guardar'])) {
     $datos = json_decode($_POST['guardar'], true);
 
+    if (floatval($datos['precio_unitario']) <= 0) {
+        echo 'PRECIO_INVALIDO';
+        return;
+    }
+
     $query = $cn->prepare(
-        "INSERT INTO detalle_remision 
-        (id_remision, id_producto, cantidad, precio_unitario, subtotal) 
+        "INSERT INTO detalle_remision
+        (id_remision, id_producto, cantidad, precio_unitario, subtotal)
         VALUES (:id_remision, :id_producto, :cantidad, :precio_unitario, :subtotal)"
     );
 
@@ -25,10 +30,13 @@ if (isset($_POST['guardar'])) {
     echo "OK";
 }
 
-
 // ACTUALIZAR DETALLE
 if (isset($_POST['actualizar'])) {
     $datos = json_decode($_POST['actualizar'], true);
+    if (floatval($datos['precio_unitario']) <= 0) {
+        echo 'PRECIO_INVALIDO';
+        return;
+    }
     $query = $cn->prepare(
         "UPDATE detalle_remision SET id_remision = :id_remision, id_producto = :id_producto, cantidad = :cantidad, precio_unitario = :precio_unitario, subtotal = :subtotal WHERE id_detalle_remision = :id_detalle_remision"
     );

--- a/paginas/referenciales/remision/agregar.php
+++ b/paginas/referenciales/remision/agregar.php
@@ -31,7 +31,7 @@
                 </div>
                 <div class="col-md-2">
                     <label for="precio_unitario_txt" class="form-label">Precio Unitario</label>
-                    <input type="number" id="precio_unitario_txt" class="form-control">
+                    <input type="number" id="precio_unitario_txt" class="form-control" min="0.01" step="0.01">
                 </div>
                 <div class="col-md-2">
                     <label for="subtotal_txt" class="form-label">Subtotal</label>

--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -62,6 +62,7 @@ function agregarDetalleRemision(){
     if($("#id_producto_lst").val() === ""){mensaje_dialogo_info_ERROR("Debe seleccionar un producto","ERROR");return;}
     if($("#cantidad_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar la cantidad","ERROR");return;}
     if($("#precio_unitario_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar el precio","ERROR");return;}
+    if(parseFloat($("#precio_unitario_txt").val()) <= 0){mensaje_dialogo_info_ERROR("El precio debe ser mayor que 0","ERROR");return;}
 
     let detalle = {
         id_producto: $("#id_producto_lst").val(),


### PR DESCRIPTION
## Summary
- Validate on the client side that a remision product's price is greater than zero
- Prevent zero-valued prices in the remision form by setting a positive minimum
- Block backend inserts/updates when remision detail price is invalid

## Testing
- `php -l controladores/detalle_remision.php`
- `php -l paginas/referenciales/remision/agregar.php`
- `node --check vistas/remision.js`


------
https://chatgpt.com/codex/tasks/task_e_689534a55a608325b6ddbb5d3a4b58fe