### PR TITLE
Validación de cantidad y precio en presupuestos

### DIFF
--- a/controladores/detalle_presupuesto.php
+++ b/controladores/detalle_presupuesto.php
@@ -7,6 +7,9 @@ $cn = $db->conectar();
 // GUARDAR DETALLE
 if (isset($_POST['guardar'])) {
     $datos = json_decode($_POST['guardar'], true);
+    if (floatval($datos['cantidad']) <= 0 || floatval($datos['precio_unitario']) <= 0) {
+        exit('Cantidad y precio_unitario deben ser mayores a cero');
+    }
     $query = $cn->prepare(
         "INSERT INTO detalle_presupuesto (id_presupuesto, id_producto, cantidad, precio_unitario, subtotal) " .
         "VALUES (:id_presupuesto, :id_producto, :cantidad, :precio_unitario, :subtotal)"
@@ -17,6 +20,9 @@ if (isset($_POST['guardar'])) {
 // ACTUALIZAR DETALLE
 if (isset($_POST['actualizar'])) {
     $datos = json_decode($_POST['actualizar'], true);
+    if (floatval($datos['cantidad']) <= 0 || floatval($datos['precio_unitario']) <= 0) {
+        exit('Cantidad y precio_unitario deben ser mayores a cero');
+    }
     $query = $cn->prepare(
         "UPDATE detalle_presupuesto SET id_presupuesto = :id_presupuesto, id_producto = :id_producto, " .
         "cantidad = :cantidad, precio_unitario = :precio_unitario, subtotal = :subtotal " .

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -74,8 +74,16 @@ function agregarDetalle(){
         mensaje_dialogo_info_ERROR("Debe ingresar la cantidad", "ERROR");
         return;
     }
+    if(parseFloat($("#cantidad_txt").val()) <= 0){
+        mensaje_dialogo_info_ERROR("La cantidad debe ser mayor a cero", "ERROR");
+        return;
+    }
     if($("#precio_unitario_txt").val().trim().length === 0){
         mensaje_dialogo_info_ERROR("Debe ingresar el costo", "ERROR");
+        return;
+    }
+    if(parseFloat($("#precio_unitario_txt").val()) <= 0){
+        mensaje_dialogo_info_ERROR("El costo debe ser mayor a cero", "ERROR");
         return;
     }
 
@@ -140,6 +148,10 @@ function guardarPresupuesto(){
     }
     if(detalles.length === 0){
         mensaje_dialogo_info_ERROR("Debe agregar al menos un producto", "ERROR");
+        return;
+    }
+    if(detalles.some(d => parseFloat(d.cantidad) <= 0 || parseFloat(d.precio_unitario) <= 0)){
+        mensaje_dialogo_info_ERROR("Los productos deben tener cantidad y costo mayores a cero", "ERROR");
         return;
     }
     let datos = {


### PR DESCRIPTION
## Resumen
- Evita registrar detalles de presupuesto con cantidad o precio unitario igual a cero en el servidor.
- Valida en la interfaz que la cantidad y el costo ingresados sean mayores a cero antes de añadir un producto.
- Impide guardar presupuestos que contengan productos con cantidad o costo no válidos.

## Pruebas
- `php -l controladores/detalle_presupuesto.php`
- `node --check vistas/presupuestos_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_6895351987f883258c1828adf4d0fe5a