### PR TITLE
Validar cantidad positiva en remisiones

### DIFF
--- a/controladores/detalle_remision.php
+++ b/controladores/detalle_remision.php
@@ -8,6 +8,11 @@ $cn = $db->conectar();
 if (isset($_POST['guardar'])) {
     $datos = json_decode($_POST['guardar'], true);
 
+    if (floatval($datos['cantidad']) <= 0) {
+        echo 'CANTIDAD_INVALIDA';
+        return;
+    }
+
     if (floatval($datos['precio_unitario']) <= 0) {
         echo 'PRECIO_INVALIDO';
         return;
@@ -33,6 +38,10 @@ if (isset($_POST['guardar'])) {
 // ACTUALIZAR DETALLE
 if (isset($_POST['actualizar'])) {
     $datos = json_decode($_POST['actualizar'], true);
+    if (floatval($datos['cantidad']) <= 0) {
+        echo 'CANTIDAD_INVALIDA';
+        return;
+    }
     if (floatval($datos['precio_unitario']) <= 0) {
         echo 'PRECIO_INVALIDO';
         return;

--- a/paginas/referenciales/remision/agregar.php
+++ b/paginas/referenciales/remision/agregar.php
@@ -27,7 +27,7 @@
                 </div>
                 <div class="col-md-2">
                     <label for="cantidad_txt" class="form-label">Cantidad</label>
-                    <input type="number" id="cantidad_txt" class="form-control" min="0">
+                    <input type="number" id="cantidad_txt" class="form-control" min="1">
                 </div>
                 <div class="col-md-2">
                     <label for="precio_unitario_txt" class="form-label">Precio Unitario</label>

--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -61,6 +61,7 @@ $(document).on('input','#cantidad_txt, #precio_unitario_txt', function(){
 function agregarDetalleRemision(){
     if($("#id_producto_lst").val() === ""){mensaje_dialogo_info_ERROR("Debe seleccionar un producto","ERROR");return;}
     if($("#cantidad_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar la cantidad","ERROR");return;}
+    if(parseFloat($("#cantidad_txt").val()) <= 0){mensaje_dialogo_info_ERROR("La cantidad debe ser mayor que 0","ERROR");return;}
     if($("#precio_unitario_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar el precio","ERROR");return;}
     if(parseFloat($("#precio_unitario_txt").val()) <= 0){mensaje_dialogo_info_ERROR("El precio debe ser mayor que 0","ERROR");return;}
 


### PR DESCRIPTION
## Summary
- Impide registrar detalles de remisión con cantidad menor o igual a cero tanto en servidor como en interfaz.
- Establece mínimo de 1 en el campo de cantidad del formulario de remisiones.

## Testing
- `php -l controladores/detalle_remision.php`
- `node --check vistas/remision.js`


------
https://chatgpt.com/codex/tasks/task_e_68966702fbfc832582ff15a1d1207a43