### PR TITLE
Add nota de crédito CRUD

### DIFF
--- a/controladores/detalle_nota_credito.php
+++ b/controladores/detalle_nota_credito.php
@@ -1,0 +1,103 @@
+<?php
+require_once '../conexion/db.php';
+
+$db = new DB();
+$cn = $db->conectar();
+
+// GUARDAR DETALLE
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+
+    if (floatval($datos['cantidad']) <= 0) {
+        echo 'CANTIDAD_INVALIDA';
+        return;
+    }
+
+    if (floatval($datos['precio_unitario']) <= 0) {
+        echo 'PRECIO_INVALIDO';
+        return;
+    }
+
+    $query = $cn->prepare("INSERT INTO detalle_nota_credito (id_nota_credito, id_producto, descripcion, cantidad, precio_unitario, subtotal, total_linea) VALUES (:id_nota_credito, :id_producto, :descripcion, :cantidad, :precio_unitario, :subtotal, :total_linea)");
+    $query->execute([
+        'id_nota_credito' => $datos['id_nota_credito'],
+        'id_producto' => $datos['id_producto'],
+        'descripcion' => $datos['descripcion'],
+        'cantidad' => $datos['cantidad'],
+        'precio_unitario' => $datos['precio_unitario'],
+        'subtotal' => $datos['subtotal'],
+        'total_linea' => $datos['total_linea']
+    ]);
+    $idDetalle = $cn->lastInsertId();
+    $cn->prepare("INSERT INTO motivo_item_nota_credito (id_detalle, motivo, observacion) VALUES (:id_detalle, :motivo, :observacion)")->execute([
+        'id_detalle' => $idDetalle,
+        'motivo' => $datos['motivo'],
+        'observacion' => $datos['observacion']
+    ]);
+    echo "OK";
+}
+
+// ACTUALIZAR DETALLE
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $query = $cn->prepare("UPDATE detalle_nota_credito SET id_nota_credito = :id_nota_credito, id_producto = :id_producto, descripcion = :descripcion, cantidad = :cantidad, precio_unitario = :precio_unitario, subtotal = :subtotal, total_linea = :total_linea WHERE id_detalle = :id_detalle");
+    $query->execute($datos);
+    $cn->prepare("UPDATE motivo_item_nota_credito SET motivo = :motivo, observacion = :observacion WHERE id_detalle = :id_detalle")->execute([
+        'motivo' => $datos['motivo'],
+        'observacion' => $datos['observacion'],
+        'id_detalle' => $datos['id_detalle']
+    ]);
+}
+
+// ELIMINAR DETALLE
+if (isset($_POST['eliminar'])) {
+    $cn->prepare("DELETE FROM motivo_item_nota_credito WHERE id_detalle = :id")->execute(['id' => $_POST['eliminar']]);
+    $cn->prepare("DELETE FROM detalle_nota_credito WHERE id_detalle = :id")->execute(['id' => $_POST['eliminar']]);
+}
+
+// ELIMINAR DETALLES POR NOTA
+if (isset($_POST['eliminar_por_nota'])) {
+    $detalles = $cn->prepare("SELECT id_detalle FROM detalle_nota_credito WHERE id_nota_credito = :id");
+    $detalles->execute(['id' => $_POST['eliminar_por_nota']]);
+    foreach ($detalles->fetchAll(PDO::FETCH_COLUMN) as $id) {
+        $cn->prepare("DELETE FROM motivo_item_nota_credito WHERE id_detalle = :id")->execute(['id' => $id]);
+    }
+    $cn->prepare("DELETE FROM detalle_nota_credito WHERE id_nota_credito = :id")->execute(['id' => $_POST['eliminar_por_nota']]);
+}
+
+// LISTAR DETALLES
+if (isset($_POST['leer'])) {
+    $sql = "SELECT d.id_detalle, d.id_nota_credito, d.id_producto, p.nombre AS producto, d.descripcion, d.cantidad, d.precio_unitario, d.subtotal, d.total_linea, m.motivo, m.observacion FROM detalle_nota_credito d LEFT JOIN productos p ON d.id_producto = p.producto_id LEFT JOIN motivo_item_nota_credito m ON d.id_detalle = m.id_detalle";
+    $params = [];
+    if (!empty($_POST['id_nota_credito'])) {
+        $sql .= " WHERE d.id_nota_credito = :id_nota_credito";
+        $params['id_nota_credito'] = $_POST['id_nota_credito'];
+    }
+    $sql .= " ORDER BY d.id_detalle DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $query = $cn->prepare("SELECT d.id_detalle, d.id_nota_credito, d.id_producto, d.descripcion, d.cantidad, d.precio_unitario, d.subtotal, d.total_linea, m.motivo, m.observacion FROM detalle_nota_credito d LEFT JOIN motivo_item_nota_credito m ON d.id_detalle = m.id_detalle WHERE d.id_detalle = :id");
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}
+
+// BUSCAR
+if (isset($_POST['leer_descripcion'])) {
+    $filtro = '%' . $_POST['leer_descripcion'] . '%';
+    $sql = "SELECT d.id_detalle, d.id_nota_credito, d.id_producto, p.nombre AS producto, d.descripcion, d.cantidad, d.precio_unitario, d.subtotal, d.total_linea, m.motivo, m.observacion FROM detalle_nota_credito d LEFT JOIN productos p ON d.id_producto = p.producto_id LEFT JOIN motivo_item_nota_credito m ON d.id_detalle = m.id_detalle WHERE CONCAT(d.id_detalle, p.nombre, d.descripcion) LIKE :filtro";
+    $params = ['filtro' => $filtro];
+    if (!empty($_POST['id_nota_credito'])) {
+        $sql .= " AND d.id_nota_credito = :id_nota_credito";
+        $params['id_nota_credito'] = $_POST['id_nota_credito'];
+    }
+    $sql .= " ORDER BY d.id_detalle DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+?>

--- a/controladores/nota_credito.php
+++ b/controladores/nota_credito.php
@@ -1,0 +1,71 @@
+<?php
+require_once '../conexion/db.php';
+
+// GUARDAR NOTA DE CREDITO
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $db = new DB();
+    $cn = $db->conectar();
+
+    $query = $cn->prepare("INSERT INTO nota_credito (fecha_emision, motivo_general, referencia_tipo, referencia_id, id_cliente, ruc_cliente, estado, total, numero_nota) VALUES (:fecha_emision, :motivo_general, :referencia_tipo, :referencia_id, :id_cliente, :ruc_cliente, :estado, :total, '')");
+    $query->execute([
+        'fecha_emision' => $datos['fecha_emision'],
+        'motivo_general' => $datos['motivo_general'],
+        'referencia_tipo' => $datos['referencia_tipo'],
+        'referencia_id' => $datos['referencia_id'],
+        'id_cliente' => $datos['id_cliente'],
+        'ruc_cliente' => $datos['ruc_cliente'],
+        'estado' => $datos['estado'],
+        'total' => $datos['total']
+    ]);
+    $id = $cn->lastInsertId();
+    $numero = 'NC-' . str_pad($id, 4, '0', STR_PAD_LEFT);
+    $cn->prepare("UPDATE nota_credito SET numero_nota = :numero WHERE id_nota_credito = :id")->execute(['numero' => $numero, 'id' => $id]);
+    echo $id;
+}
+
+// ACTUALIZAR NOTA DE CREDITO
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare("UPDATE nota_credito SET fecha_emision = :fecha_emision, motivo_general = :motivo_general, referencia_tipo = :referencia_tipo, referencia_id = :referencia_id, id_cliente = :id_cliente, ruc_cliente = :ruc_cliente, estado = :estado, total = :total WHERE id_nota_credito = :id_nota_credito");
+    $query->execute($datos);
+}
+
+// ANULAR NOTA DE CREDITO
+if (isset($_POST['anular'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare("UPDATE nota_credito SET estado = 'ANULADO' WHERE id_nota_credito = :id");
+    $query->execute(['id' => $_POST['anular']]);
+}
+
+// LEER TODAS
+if (isset($_POST['leer'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare("SELECT n.id_nota_credito, n.fecha_emision, n.numero_nota, n.id_cliente, c.nombre_apellido AS cliente, n.motivo_general, n.estado, IFNULL(SUM(d.total_linea),0) AS total FROM nota_credito n LEFT JOIN clientes c ON n.id_cliente = c.id_cliente LEFT JOIN detalle_nota_credito d ON n.id_nota_credito = d.id_nota_credito GROUP BY n.id_nota_credito, n.fecha_emision, n.numero_nota, n.id_cliente, c.nombre_apellido, n.motivo_general, n.estado ORDER BY n.id_nota_credito DESC");
+    $query->execute();
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare("SELECT n.id_nota_credito, n.fecha_emision, n.numero_nota, n.id_cliente, c.nombre_apellido AS cliente, n.motivo_general, n.referencia_tipo, n.referencia_id, n.ruc_cliente, n.estado, n.total FROM nota_credito n LEFT JOIN clientes c ON n.id_cliente = c.id_cliente WHERE n.id_nota_credito = :id");
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}
+
+// BUSCAR
+if (isset($_POST['leer_descripcion'])) {
+    $f = '%' . $_POST['leer_descripcion'] . '%';
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare("SELECT n.id_nota_credito, n.fecha_emision, n.numero_nota, n.id_cliente, c.nombre_apellido AS cliente, n.motivo_general, n.estado, IFNULL(SUM(d.total_linea),0) AS total FROM nota_credito n LEFT JOIN clientes c ON n.id_cliente = c.id_cliente LEFT JOIN detalle_nota_credito d ON n.id_nota_credito = d.id_nota_credito WHERE c.nombre_apellido LIKE :filtro OR n.numero_nota LIKE :filtro GROUP BY n.id_nota_credito, n.fecha_emision, n.numero_nota, n.id_cliente, c.nombre_apellido, n.motivo_general, n.estado ORDER BY n.id_nota_credito DESC");
+    $query->execute(['filtro' => $f]);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+?>

--- a/menu.php
+++ b/menu.php
@@ -422,7 +422,7 @@
 </li>
 
 <li class="nav-item">
-  <a href="#" class="nav-link ">
+  <a href="#" class="nav-link" onclick="mostrarListarNotaCredito(); return false;">
     <i class="nav-icon bi bi-file-earmark-text"></i>
     <p>Nota de Credito</p>
   </a>
@@ -448,7 +448,7 @@
 </li>
 
 <li class="nav-item">
-  <a href="#" class="nav-link ">
+  <a href="#" class="nav-link" onclick="mostrarListarNotaCredito(); return false;">
     <i class="nav-icon bi bi-file-earmark-text"></i>
     <p>Diagnostico</p>
   </a>
@@ -773,6 +773,7 @@
     <script src="vistas/cliente.js"></script>
     <script src="vistas/productos.js"></script>
     <script src="vistas/remision.js"></script>
+    <script src="vistas/nota_credito.js"></script>
     <!--end::Script-->
   </body>
   <!--end::Body-->

--- a/paginas/referenciales/nota_credito/agregar.php
+++ b/paginas/referenciales/nota_credito/agregar.php
@@ -1,0 +1,113 @@
+<div class="container mt-4">
+    <input type="hidden" id="id_nota_credito" value="0">
+    <input type="hidden" id="estado_txt" value="ACTIVO">
+    <div class="card shadow rounded-4">
+        <div class="card-header bg-primary text-white rounded-top-4">
+            <h4 class="mb-0">Agregar / Editar Nota de Crédito</h4>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <label for="id_cliente_lst" class="form-label">Cliente</label>
+                    <select id="id_cliente_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-2">
+                    <label for="ruc_cliente_txt" class="form-label">RUC</label>
+                    <input type="text" id="ruc_cliente_txt" class="form-control" readonly>
+                </div>
+                <div class="col-md-2">
+                    <label for="fecha_txt" class="form-label">Fecha</label>
+                    <input type="date" id="fecha_txt" class="form-control" value="<?php echo date('Y-m-d'); ?>">
+                </div>
+                <div class="col-md-4">
+                    <label for="motivo_general_txt" class="form-label">Motivo General</label>
+                    <input type="text" id="motivo_general_txt" class="form-control">
+                </div>
+            </div>
+            <div class="row g-3 mt-3">
+                <div class="col-md-3">
+                    <label for="referencia_tipo_txt" class="form-label">Referencia Tipo</label>
+                    <input type="text" id="referencia_tipo_txt" class="form-control">
+                </div>
+                <div class="col-md-3">
+                    <label for="referencia_id_txt" class="form-label">Referencia ID</label>
+                    <input type="number" id="referencia_id_txt" class="form-control" min="0">
+                </div>
+                <div class="col-md-3">
+                    <label for="numero_nota_txt" class="form-label">Número Nota</label>
+                    <input type="text" id="numero_nota_txt" class="form-control" readonly>
+                </div>
+                <div class="col-md-3">
+                    <label for="total_general_txt" class="form-label">Total</label>
+                    <input type="text" id="total_general_txt" class="form-control" readonly value="0">
+                </div>
+            </div>
+            <hr class="my-4">
+            <div class="row g-3">
+                <div class="col-md-3">
+                    <label for="id_producto_lst" class="form-label">Producto</label>
+                    <select id="id_producto_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-3">
+                    <label for="descripcion_txt" class="form-label">Descripción</label>
+                    <input type="text" id="descripcion_txt" class="form-control" readonly>
+                </div>
+                <div class="col-md-2">
+                    <label for="cantidad_txt" class="form-label">Cantidad</label>
+                    <input type="number" id="cantidad_txt" class="form-control" min="1">
+                </div>
+                <div class="col-md-2">
+                    <label for="precio_unitario_txt" class="form-label">Precio Unitario</label>
+                    <input type="number" id="precio_unitario_txt" class="form-control" min="0.01" step="0.01">
+                </div>
+                <div class="col-md-2">
+                    <label for="subtotal_txt" class="form-label">Subtotal</label>
+                    <input type="number" id="subtotal_txt" class="form-control" readonly>
+                </div>
+            </div>
+            <div class="row g-3 mt-3">
+                <div class="col-md-4">
+                    <label for="motivo_item_txt" class="form-label">Motivo</label>
+                    <input type="text" id="motivo_item_txt" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="observacion_txt" class="form-label">Observación</label>
+                    <input type="text" id="observacion_txt" class="form-control">
+                </div>
+                <div class="col-md-2 d-grid align-items-end">
+                    <button class="btn btn-primary" onclick="agregarDetalleNotaCredito(); return false;">
+                        <i class="bi bi-plus-lg"></i> Agregar Item
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="card-footer text-end">
+            <button class="btn btn-success me-2" onclick="guardarNotaCredito(); return false;">
+                <i class="bi bi-save"></i> Guardar
+            </button>
+            <button class="btn btn-danger" onclick="mostrarListarNotaCredito(); return false;">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="container mt-4">
+    <div class="table-responsive">
+        <table class="table table-bordered text-center align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>Producto</th>
+                    <th>Descripción</th>
+                    <th>Cantidad</th>
+                    <th>Precio Unitario</th>
+                    <th>Subtotal</th>
+                    <th>Motivo</th>
+                    <th>Observación</th>
+                    <th>Acción</th>
+                </tr>
+            </thead>
+            <tbody id="detalle_nota_tb"></tbody>
+        </table>
+    </div>
+</div>

--- a/paginas/referenciales/nota_credito/listar.php
+++ b/paginas/referenciales/nota_credito/listar.php
@@ -1,0 +1,39 @@
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">Listado de Notas de Crédito</h4>
+        <button class="btn btn-primary" onclick="mostrarAgregarNotaCredito(); return false;">
+            <i class="bi bi-plus-circle"></i> Agregar
+        </button>
+    </div>
+    <div class="card shadow-sm rounded-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-8">
+                    <label for="b_nota_credito" class="form-label">Buscador</label>
+                    <input type="text" id="b_nota_credito" class="form-control" placeholder="Buscar por cliente o número...">
+                </div>
+                <div class="col-md-4">
+                    <button class="btn btn-secondary w-100" onclick="buscarNotaCredito(); return false;">
+                        <i class="bi bi-search"></i> Buscar
+                    </button>
+                </div>
+            </div>
+            <div class="table-responsive mt-4">
+                <table class="table table-bordered table-hover align-middle text-center">
+                    <thead class="table-light">
+                        <tr>
+                            <th>#</th>
+                            <th>Número</th>
+                            <th>Fecha</th>
+                            <th>Cliente</th>
+                            <th>Total</th>
+                            <th>Estado</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="nota_credito_datos_tb"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/utcdp1.sql
+++ b/utcdp1.sql
@@ -613,3 +613,65 @@ COMMIT;
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `nota_credito`
+--
+CREATE TABLE `nota_credito` (
+  `id_nota_credito` int(11) NOT NULL AUTO_INCREMENT,
+  `fecha_emision` date NOT NULL,
+  `numero_nota` varchar(20) NOT NULL,
+  `motivo_general` varchar(255) DEFAULT NULL,
+  `referencia_tipo` varchar(50) DEFAULT NULL,
+  `referencia_id` int(11) DEFAULT NULL,
+  `id_cliente` int(11) NOT NULL,
+  `ruc_cliente` varchar(20) DEFAULT NULL,
+  `estado` varchar(20) DEFAULT 'ACTIVO',
+  `total` decimal(12,2) DEFAULT 0,
+  PRIMARY KEY (`id_nota_credito`),
+  KEY `id_cliente` (`id_cliente`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `detalle_nota_credito`
+--
+CREATE TABLE `detalle_nota_credito` (
+  `id_detalle` int(11) NOT NULL AUTO_INCREMENT,
+  `id_nota_credito` int(11) NOT NULL,
+  `id_producto` int(11) NOT NULL,
+  `descripcion` varchar(255) DEFAULT NULL,
+  `cantidad` int(11) NOT NULL,
+  `precio_unitario` decimal(12,2) NOT NULL,
+  `subtotal` decimal(12,2) NOT NULL,
+  `total_linea` decimal(12,2) NOT NULL,
+  PRIMARY KEY (`id_detalle`),
+  KEY `id_nota_credito` (`id_nota_credito`),
+  KEY `id_producto` (`id_producto`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `motivo_item_nota_credito`
+--
+CREATE TABLE `motivo_item_nota_credito` (
+  `id_motivo_item` int(11) NOT NULL AUTO_INCREMENT,
+  `id_detalle` int(11) NOT NULL,
+  `motivo` varchar(255) NOT NULL,
+  `observacion` text DEFAULT NULL,
+  PRIMARY KEY (`id_motivo_item`),
+  KEY `id_detalle` (`id_detalle`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Filtros para las tablas nuevas
+--
+ALTER TABLE `nota_credito`
+  ADD CONSTRAINT `nota_credito_ibfk_1` FOREIGN KEY (`id_cliente`) REFERENCES `clientes` (`id_cliente`);
+ALTER TABLE `detalle_nota_credito`
+  ADD CONSTRAINT `detalle_nota_credito_ibfk_1` FOREIGN KEY (`id_nota_credito`) REFERENCES `nota_credito` (`id_nota_credito`),
+  ADD CONSTRAINT `detalle_nota_credito_ibfk_2` FOREIGN KEY (`id_producto`) REFERENCES `productos` (`producto_id`);
+ALTER TABLE `motivo_item_nota_credito`
+  ADD CONSTRAINT `motivo_item_nota_credito_ibfk_1` FOREIGN KEY (`id_detalle`) REFERENCES `detalle_nota_credito` (`id_detalle`);

--- a/vistas/nota_credito.js
+++ b/vistas/nota_credito.js
@@ -1,0 +1,258 @@
+(function(){
+    let detallesNota = [];
+    let listaClientes = [];
+    let listaProductos = [];
+    window.detallesNota = detallesNota;
+})();
+
+function mostrarListarNotaCredito(){
+    let contenido = dameContenido("paginas/referenciales/nota_credito/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaNotaCredito();
+}
+window.mostrarListarNotaCredito = mostrarListarNotaCredito;
+
+function mostrarAgregarNotaCredito(){
+    let contenido = dameContenido("paginas/referenciales/nota_credito/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaClientes();
+    cargarListaProductos();
+    detallesNota = [];
+    renderDetallesNota();
+}
+window.mostrarAgregarNotaCredito = mostrarAgregarNotaCredito;
+
+function cargarListaClientes(){
+    let datos = ejecutarAjax("controladores/cliente.php","leer=1");
+    if(datos !== "0"){
+        listaClientes = JSON.parse(datos);
+        let select = $("#id_cliente_lst");
+        select.html('<option value="">-- Seleccione un cliente --</option>');
+        listaClientes.forEach(c => select.append(`<option value="${c.id_cliente}" data-ruc="${c.ruc}">${c.nombre_apellido}</option>`));
+    }
+}
+
+$(document).on('change','#id_cliente_lst',function(){
+    let ruc = $("#id_cliente_lst option:selected").data('ruc') || '';
+    $('#ruc_cliente_txt').val(ruc);
+});
+
+function cargarListaProductos(){
+    let datos = ejecutarAjax("controladores/productos.php","leerActivo=1");
+    if(datos !== "0"){
+        listaProductos = JSON.parse(datos);
+        let select = $("#id_producto_lst");
+        select.html('<option value="">-- Seleccione un producto --</option>');
+        listaProductos.forEach(p => select.append(`<option value="${p.producto_id}" data-precio="${p.precio}" data-descripcion="${p.nombre}">${p.nombre}</option>`));
+    }
+}
+
+$(document).on('change','#id_producto_lst',function(){
+    let desc = $("#id_producto_lst option:selected").data('descripcion') || '';
+    $('#descripcion_txt').val(desc);
+});
+
+$(document).on('input','#cantidad_txt, #precio_unitario_txt', function(){
+    const cant = parseFloat($('#cantidad_txt').val()) || 0;
+    const precio = parseFloat($('#precio_unitario_txt').val()) || 0;
+    const subtotal = cant * precio;
+    $('#subtotal_txt').val(formatearPY(subtotal));
+});
+
+function agregarDetalleNotaCredito(){
+    if($("#id_producto_lst").val() === ""){mensaje_dialogo_info_ERROR("Debe seleccionar un producto","ERROR");return;}
+    if($("#cantidad_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar la cantidad","ERROR");return;}
+    if(parseFloat($("#cantidad_txt").val()) <= 0){mensaje_dialogo_info_ERROR("La cantidad debe ser mayor que 0","ERROR");return;}
+    if($("#precio_unitario_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar el precio","ERROR");return;}
+    if(parseFloat($("#precio_unitario_txt").val()) <= 0){mensaje_dialogo_info_ERROR("El precio debe ser mayor que 0","ERROR");return;}
+
+    let detalle = {
+        id_producto: $("#id_producto_lst").val(),
+        producto: $("#id_producto_lst option:selected").text(),
+        descripcion: $("#descripcion_txt").val(),
+        cantidad: $("#cantidad_txt").val(),
+        precio_unitario: $("#precio_unitario_txt").val(),
+        subtotal: (parseFloat($("#cantidad_txt").val()) || 0) * (parseFloat($("#precio_unitario_txt").val()) || 0),
+        total_linea: (parseFloat($("#cantidad_txt").val()) || 0) * (parseFloat($("#precio_unitario_txt").val()) || 0),
+        motivo: $("#motivo_item_txt").val(),
+        observacion: $("#observacion_txt").val()
+    };
+    detallesNota.push(detalle);
+    renderDetallesNota();
+    limpiarDetalleNotaForm();
+}
+window.agregarDetalleNotaCredito = agregarDetalleNotaCredito;
+
+function limpiarDetalleNotaForm(){
+    $("#id_producto_lst").val("");
+    $("#descripcion_txt").val("");
+    $("#cantidad_txt").val("");
+    $("#precio_unitario_txt").val("");
+    $("#subtotal_txt").val("");
+    $("#motivo_item_txt").val("");
+    $("#observacion_txt").val("");
+}
+
+function renderDetallesNota(){
+    let tbody = $("#detalle_nota_tb");
+    tbody.html("");
+    let total = 0;
+    detallesNota.forEach((d,i) => {
+        total += parseFloat(d.total_linea);
+        tbody.append(`<tr>
+            <td>${d.producto}</td>
+            <td>${d.descripcion}</td>
+            <td>${d.cantidad}</td>
+            <td>${formatearPY(d.precio_unitario)}</td>
+            <td>${formatearPY(d.total_linea)}</td>
+            <td>${d.motivo}</td>
+            <td>${d.observacion}</td>
+            <td><button class="btn btn-danger btn-sm" onclick="eliminarDetalleNota(${i}); return false;"><i class="bi bi-trash"></i></button></td>
+        </tr>`);
+    });
+    $("#total_general_txt").val(formatearPY(total));
+}
+
+function eliminarDetalleNota(index){
+    detallesNota.splice(index,1);
+    renderDetallesNota();
+}
+window.eliminarDetalleNota = eliminarDetalleNota;
+
+function guardarNotaCredito(){
+    if($("#id_cliente_lst").val() === ""){mensaje_dialogo_info_ERROR("Debe seleccionar un cliente","ERROR");return;}
+    if($("#fecha_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar la fecha","ERROR");return;}
+    if(detallesNota.length === 0){mensaje_dialogo_info_ERROR("Debe agregar al menos un item","ERROR");return;}
+
+    let total = detallesNota.reduce((acc,d)=>acc+parseFloat(d.total_linea),0);
+
+    let datos = {
+        fecha_emision: $("#fecha_txt").val(),
+        motivo_general: $("#motivo_general_txt").val(),
+        referencia_tipo: $("#referencia_tipo_txt").val(),
+        referencia_id: $("#referencia_id_txt").val(),
+        id_cliente: $("#id_cliente_lst").val(),
+        ruc_cliente: $("#ruc_cliente_txt").val(),
+        estado: $("#estado_txt").val(),
+        total: total
+    };
+
+    let idNota = $("#id_nota_credito").val();
+    if(idNota === "0"){
+        idNota = ejecutarAjax("controladores/nota_credito.php","guardar="+JSON.stringify(datos));
+        detallesNota.forEach(function(d){
+            let det = { ...d, id_nota_credito: idNota };
+            ejecutarAjax("controladores/detalle_nota_credito.php","guardar="+JSON.stringify(det));
+        });
+    }else{
+        datos = { ...datos, id_nota_credito: idNota };
+        ejecutarAjax("controladores/nota_credito.php","actualizar="+JSON.stringify(datos));
+        ejecutarAjax("controladores/detalle_nota_credito.php","eliminar_por_nota="+idNota);
+        detallesNota.forEach(function(d){
+            let det = { ...d, id_nota_credito: idNota };
+            ejecutarAjax("controladores/detalle_nota_credito.php","guardar="+JSON.stringify(det));
+        });
+    }
+    mensaje_confirmacion("Guardado correctamente");
+    mostrarListarNotaCredito();
+}
+window.guardarNotaCredito = guardarNotaCredito;
+
+function cargarTablaNotaCredito(){
+    let datos = ejecutarAjax("controladores/nota_credito.php","leer=1");
+    if(datos === "0"){
+        $("#nota_credito_datos_tb").html("NO HAY REGISTROS");
+    }else{
+        let json = JSON.parse(datos);
+        $("#nota_credito_datos_tb").html("");
+        json.map(function(it){
+            $("#nota_credito_datos_tb").append(`
+                <tr>
+                    <td>${it.id_nota_credito}</td>
+                    <td>${it.numero_nota}</td>
+                    <td>${it.fecha_emision}</td>
+                    <td>${it.cliente}</td>
+                    <td>${formatearPY(it.total)}</td>
+                    <td>${badgeEstado(it.estado)}</td>
+                    <td>
+                        <button class="btn btn-warning btn-sm editar-nota" title="Editar"><i class="bi bi-pencil-square"></i></button>
+                        <button class="btn btn-danger btn-sm anular-nota" title="Anular"><i class="bi bi-x-circle"></i></button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+window.cargarTablaNotaCredito = cargarTablaNotaCredito;
+
+function buscarNotaCredito(){
+    let b = $("#b_nota_credito").val();
+    let datos = ejecutarAjax("controladores/nota_credito.php","leer_descripcion="+b);
+    if(datos === "0"){
+        $("#nota_credito_datos_tb").html("NO HAY REGISTROS");
+    }else{
+        let json = JSON.parse(datos);
+        $("#nota_credito_datos_tb").html("");
+        json.map(function(it){
+            $("#nota_credito_datos_tb").append(`
+                <tr>
+                    <td>${it.id_nota_credito}</td>
+                    <td>${it.numero_nota}</td>
+                    <td>${it.fecha_emision}</td>
+                    <td>${it.cliente}</td>
+                    <td>${formatearPY(it.total)}</td>
+                    <td>${badgeEstado(it.estado)}</td>
+                    <td>
+                        <button class="btn btn-warning btn-sm editar-nota" title="Editar"><i class="bi bi-pencil-square"></i></button>
+                        <button class="btn btn-danger btn-sm anular-nota" title="Anular"><i class="bi bi-x-circle"></i></button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+window.buscarNotaCredito = buscarNotaCredito;
+
+$(document).on("click",".editar-nota",function(){
+    let id=$(this).closest("tr").find("td:eq(0)").text();
+    mostrarAgregarNotaCredito();
+    setTimeout(function(){
+        let datos=ejecutarAjax("controladores/nota_credito.php","leer_id="+id);
+        let json=JSON.parse(datos);
+        $("#id_nota_credito").val(json.id_nota_credito);
+        $("#id_cliente_lst").val(json.id_cliente).trigger('change');
+        $("#fecha_txt").val(json.fecha_emision);
+        $("#motivo_general_txt").val(json.motivo_general);
+        $("#referencia_tipo_txt").val(json.referencia_tipo);
+        $("#referencia_id_txt").val(json.referencia_id);
+        $("#numero_nota_txt").val(json.numero_nota);
+        $("#ruc_cliente_txt").val(json.ruc_cliente);
+        $("#estado_txt").val(json.estado);
+        let det=ejecutarAjax("controladores/detalle_nota_credito.php","leer=1&id_nota_credito="+id);
+        if(det !== "0"){
+            detallesNota=JSON.parse(det).map(d=>({id_producto:d.id_producto,producto:d.producto,descripcion:d.descripcion,cantidad:d.cantidad,precio_unitario:d.precio_unitario,subtotal:d.subtotal,total_linea:d.total_linea,motivo:d.motivo,observacion:d.observacion}));
+        }else{
+            detallesNota=[];
+        }
+        renderDetallesNota();
+    },100);
+});
+
+$(document).on("click",".anular-nota",function(){
+    let id=$(this).closest("tr").find("td:eq(0)").text();
+    Swal.fire({
+        title:"¿Anular nota de crédito?",
+        text:"Esta acción marcará la nota como anulada.",
+        icon:"warning",
+        showCancelButton:true,
+        confirmButtonText:"Sí, anular",
+        cancelButtonText:"Cancelar",
+        confirmButtonColor:"#dc3545",
+        cancelButtonColor:"#6c757d",
+        reverseButtons:true
+    }).then((result)=>{
+        if(result.isConfirmed){
+            ejecutarAjax("controladores/nota_credito.php","anular="+id);
+            mensaje_confirmacion("Anulado correctamente");
+            cargarTablaNotaCredito();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add database schema for `nota_credito` with details and item motives
- implement controllers and pages for full nota de crédito CRUD
- include frontend JS and menu link to manage credit notes

## Testing
- `php -l controladores/nota_credito.php`
- `php -l controladores/detalle_nota_credito.php`
- `php -l paginas/referenciales/nota_credito/agregar.php`
- `php -l paginas/referenciales/nota_credito/listar.php`
- `php -l menu.php`


------
https://chatgpt.com/codex/tasks/task_e_68966eddb064832586f27379c310ff12