### PR TITLE
Remove credit note references and add printing

### DIFF
--- a/controladores/nota_credito.php
+++ b/controladores/nota_credito.php
@@ -7,12 +7,10 @@ if (isset($_POST['guardar'])) {
     $db = new DB();
     $cn = $db->conectar();
 
-    $query = $cn->prepare("INSERT INTO nota_credito (fecha_emision, motivo_general, referencia_tipo, referencia_id, id_cliente, ruc_cliente, estado, total, numero_nota) VALUES (:fecha_emision, :motivo_general, :referencia_tipo, :referencia_id, :id_cliente, :ruc_cliente, :estado, :total, '')");
+    $query = $cn->prepare("INSERT INTO nota_credito (fecha_emision, motivo_general, id_cliente, ruc_cliente, estado, total, numero_nota) VALUES (:fecha_emision, :motivo_general, :id_cliente, :ruc_cliente, :estado, :total, '')");
     $query->execute([
         'fecha_emision' => $datos['fecha_emision'],
         'motivo_general' => $datos['motivo_general'],
-        'referencia_tipo' => $datos['referencia_tipo'],
-        'referencia_id' => $datos['referencia_id'],
         'id_cliente' => $datos['id_cliente'],
         'ruc_cliente' => $datos['ruc_cliente'],
         'estado' => $datos['estado'],
@@ -29,7 +27,7 @@ if (isset($_POST['actualizar'])) {
     $datos = json_decode($_POST['actualizar'], true);
     $db = new DB();
     $cn = $db->conectar();
-    $query = $cn->prepare("UPDATE nota_credito SET fecha_emision = :fecha_emision, motivo_general = :motivo_general, referencia_tipo = :referencia_tipo, referencia_id = :referencia_id, id_cliente = :id_cliente, ruc_cliente = :ruc_cliente, estado = :estado, total = :total WHERE id_nota_credito = :id_nota_credito");
+    $query = $cn->prepare("UPDATE nota_credito SET fecha_emision = :fecha_emision, motivo_general = :motivo_general, id_cliente = :id_cliente, ruc_cliente = :ruc_cliente, estado = :estado, total = :total WHERE id_nota_credito = :id_nota_credito");
     $query->execute($datos);
 }
 
@@ -54,7 +52,7 @@ if (isset($_POST['leer'])) {
 if (isset($_POST['leer_id'])) {
     $db = new DB();
     $cn = $db->conectar();
-    $query = $cn->prepare("SELECT n.id_nota_credito, n.fecha_emision, n.numero_nota, n.id_cliente, c.nombre_apellido AS cliente, n.motivo_general, n.referencia_tipo, n.referencia_id, n.ruc_cliente, n.estado, n.total FROM nota_credito n LEFT JOIN clientes c ON n.id_cliente = c.id_cliente WHERE n.id_nota_credito = :id");
+    $query = $cn->prepare("SELECT n.id_nota_credito, n.fecha_emision, n.numero_nota, n.id_cliente, c.nombre_apellido AS cliente, n.motivo_general, n.ruc_cliente, n.estado, n.total FROM nota_credito n LEFT JOIN clientes c ON n.id_cliente = c.id_cliente WHERE n.id_nota_credito = :id");
     $query->execute(['id' => $_POST['leer_id']]);
     echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
 }

--- a/paginas/referenciales/nota_credito/agregar.php
+++ b/paginas/referenciales/nota_credito/agregar.php
@@ -25,19 +25,11 @@
                 </div>
             </div>
             <div class="row g-3 mt-3">
-                <div class="col-md-3">
-                    <label for="referencia_tipo_txt" class="form-label">Referencia Tipo</label>
-                    <input type="text" id="referencia_tipo_txt" class="form-control">
-                </div>
-                <div class="col-md-3">
-                    <label for="referencia_id_txt" class="form-label">Referencia ID</label>
-                    <input type="number" id="referencia_id_txt" class="form-control" min="0">
-                </div>
-                <div class="col-md-3">
+                <div class="col-md-6">
                     <label for="numero_nota_txt" class="form-label">Número Nota</label>
                     <input type="text" id="numero_nota_txt" class="form-control" readonly>
                 </div>
-                <div class="col-md-3">
+                <div class="col-md-6">
                     <label for="total_general_txt" class="form-label">Total</label>
                     <input type="text" id="total_general_txt" class="form-control" readonly value="0">
                 </div>


### PR DESCRIPTION
## Summary
- remove reference type and ID fields from credit note forms and controller
- add per-note print button that shows general and item-specific motives

## Testing
- `node --check vistas/nota_credito.js`
- `php -l controladores/nota_credito.php`
- `php -l paginas/referenciales/nota_credito/agregar.php`


------
https://chatgpt.com/codex/tasks/task_e_6896783cee1c83258a96ba41b49dabf5