### PR TITLE
feat: add recepcion module with detail CRUD

### DIFF
--- a/controladores/detalle_recepcion.php
+++ b/controladores/detalle_recepcion.php
@@ -1,0 +1,76 @@
+<?php
+require_once '../conexion/db.php';
+
+$db = new DB();
+$cn = $db->conectar();
+
+// GUARDAR DETALLE
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $query = $cn->prepare(
+        "INSERT INTO recepcion_detalle (id_recepcion, marca, modelo, numero_serie, falla_reportada, accesorios_entregados, diagnostico_preliminar, estado_equipo, observaciones_detalle)
+        VALUES (:id_recepcion, :marca, :modelo, :numero_serie, :falla_reportada, :accesorios_entregados, :diagnostico_preliminar, :estado_equipo, :observaciones_detalle)"
+    );
+    $query->execute($datos);
+    echo 'OK';
+}
+
+// ACTUALIZAR DETALLE
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $query = $cn->prepare(
+        "UPDATE recepcion_detalle SET id_recepcion = :id_recepcion, marca = :marca, modelo = :modelo, numero_serie = :numero_serie, falla_reportada = :falla_reportada, accesorios_entregados = :accesorios_entregados, diagnostico_preliminar = :diagnostico_preliminar, estado_equipo = :estado_equipo, observaciones_detalle = :observaciones_detalle WHERE id_detalle = :id_detalle"
+    );
+    $query->execute($datos);
+}
+
+// ELIMINAR DETALLE
+if (isset($_POST['eliminar'])) {
+    $query = $cn->prepare("DELETE FROM recepcion_detalle WHERE id_detalle = :id");
+    $query->execute(['id' => $_POST['eliminar']]);
+}
+
+// ELIMINAR DETALLES POR RECEPCION
+if (isset($_POST['eliminar_por_recepcion'])) {
+    $query = $cn->prepare("DELETE FROM recepcion_detalle WHERE id_recepcion = :id");
+    $query->execute(['id' => $_POST['eliminar_por_recepcion']]);
+}
+
+// LISTAR DETALLES
+if (isset($_POST['leer'])) {
+    $sql = "SELECT id_detalle, id_recepcion, marca, modelo, numero_serie, falla_reportada, accesorios_entregados, diagnostico_preliminar, estado_equipo, observaciones_detalle FROM recepcion_detalle";
+    $params = [];
+    if (!empty($_POST['id_recepcion'])) {
+        $sql .= " WHERE id_recepcion = :id_recepcion";
+        $params['id_recepcion'] = $_POST['id_recepcion'];
+    }
+    $sql .= " ORDER BY id_detalle DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $query = $cn->prepare(
+        "SELECT id_detalle, id_recepcion, marca, modelo, numero_serie, falla_reportada, accesorios_entregados, diagnostico_preliminar, estado_equipo, observaciones_detalle FROM recepcion_detalle WHERE id_detalle = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}
+
+// BUSCAR
+if (isset($_POST['leer_descripcion'])) {
+    $filtro = '%' . $_POST['leer_descripcion'] . '%';
+    $sql = "SELECT id_detalle, id_recepcion, marca, modelo, numero_serie, falla_reportada, accesorios_entregados, diagnostico_preliminar, estado_equipo, observaciones_detalle FROM recepcion_detalle WHERE CONCAT(marca, modelo, numero_serie, estado_equipo) LIKE :filtro";
+    $params = ['filtro' => $filtro];
+    if (!empty($_POST['id_recepcion'])) {
+        $sql .= " AND id_recepcion = :id_recepcion";
+        $params['id_recepcion'] = $_POST['id_recepcion'];
+    }
+    $sql .= " ORDER BY id_detalle DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+?>

--- a/controladores/recepcion.php
+++ b/controladores/recepcion.php
@@ -1,0 +1,86 @@
+<?php
+require_once '../conexion/db.php';
+
+// GUARDAR RECEPCION
+if (isset($_POST['guardar'])) {
+    $datos = json_decode($_POST['guardar'], true);
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "INSERT INTO recepcion (fecha_recepcion, id_cliente, nombre_cliente, telefono, direccion, estado, observaciones)
+        VALUES (:fecha_recepcion, :id_cliente, :nombre_cliente, :telefono, :direccion, :estado, :observaciones)"
+    );
+    $query->execute($datos);
+    echo $cn->lastInsertId();
+}
+
+// ACTUALIZAR RECEPCION
+if (isset($_POST['actualizar'])) {
+    $datos = json_decode($_POST['actualizar'], true);
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "UPDATE recepcion SET fecha_recepcion = :fecha_recepcion, id_cliente = :id_cliente, nombre_cliente = :nombre_cliente, telefono = :telefono, direccion = :direccion, estado = :estado, observaciones = :observaciones WHERE id_recepcion = :id_recepcion"
+    );
+    $query->execute($datos);
+}
+
+// CERRAR RECEPCION
+if (isset($_POST['cerrar'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare("UPDATE recepcion SET estado = 'CERRADA' WHERE id_recepcion = :id");
+    $query->execute(['id' => $_POST['cerrar']]);
+}
+
+// ELIMINAR RECEPCION
+if (isset($_POST['eliminar'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare("DELETE FROM recepcion WHERE id_recepcion = :id");
+    $query->execute(['id' => $_POST['eliminar']]);
+}
+
+// LISTAR RECEPCIONES
+if (isset($_POST['leer'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "SELECT r.id_recepcion, r.fecha_recepcion, r.nombre_cliente, r.telefono, r.direccion, r.estado, r.observaciones, IFNULL(COUNT(d.id_detalle),0) AS equipos
+         FROM recepcion r
+         LEFT JOIN recepcion_detalle d ON r.id_recepcion = d.id_recepcion
+         GROUP BY r.id_recepcion, r.fecha_recepcion, r.nombre_cliente, r.telefono, r.direccion, r.estado, r.observaciones
+         ORDER BY r.id_recepcion DESC"
+    );
+    $query->execute();
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+// LEER POR ID
+if (isset($_POST['leer_id'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "SELECT id_recepcion, fecha_recepcion, id_cliente, nombre_cliente, telefono, direccion, estado, observaciones FROM recepcion WHERE id_recepcion = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}
+
+// BUSCAR POR DESCRIPCION (NOMBRE CLIENTE)
+if (isset($_POST['leer_descripcion'])) {
+    $f = '%' . $_POST['leer_descripcion'] . '%';
+    $db = new DB();
+    $cn = $db->conectar();
+    $query = $cn->prepare(
+        "SELECT r.id_recepcion, r.fecha_recepcion, r.nombre_cliente, r.telefono, r.direccion, r.estado, r.observaciones, IFNULL(COUNT(d.id_detalle),0) AS equipos
+         FROM recepcion r
+         LEFT JOIN recepcion_detalle d ON r.id_recepcion = d.id_recepcion
+         WHERE CONCAT(r.nombre_cliente, r.telefono, r.direccion, r.estado, r.observaciones) LIKE :filtro
+         GROUP BY r.id_recepcion, r.fecha_recepcion, r.nombre_cliente, r.telefono, r.direccion, r.estado, r.observaciones
+         ORDER BY r.id_recepcion DESC"
+    );
+    $query->execute(['filtro' => $f]);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+?>

--- a/menu.php
+++ b/menu.php
@@ -441,7 +441,7 @@
                 
                   
 <li class="nav-item">
-  <a href="#" class="nav-link" onclick= ; return false;">
+  <a href="#" class="nav-link" onclick="mostrarListarRecepcion(); return false;">
     <i class="nav-icon bi bi-file-earmark-text"></i>
     <p>Recepcion</p>
   </a>
@@ -773,6 +773,7 @@
     <script src="vistas/cliente.js"></script>
     <script src="vistas/productos.js"></script>
     <script src="vistas/remision.js"></script>
+    <script src="vistas/recepcion.js"></script>
     <script src="vistas/nota_credito.js"></script>
     <!--end::Script-->
   </body>

--- a/paginas/referenciales/recepcion/agregar.php
+++ b/paginas/referenciales/recepcion/agregar.php
@@ -1,0 +1,108 @@
+<div class="container mt-4">
+    <input type="hidden" id="id_recepcion" value="0">
+    <div class="card shadow rounded-4">
+        <div class="card-header bg-primary text-white rounded-top-4">
+            <h4 class="mb-0">Agregar / Editar Recepción</h4>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-3">
+                    <label for="fecha_txt" class="form-label">Fecha</label>
+                    <input type="date" id="fecha_txt" class="form-control" value="<?php echo date('Y-m-d'); ?>">
+                </div>
+                <div class="col-md-4">
+                    <label for="id_cliente_lst" class="form-label">Cliente</label>
+                    <select id="id_cliente_lst" class="form-select"></select>
+                </div>
+                <div class="col-md-2">
+                    <label for="telefono_txt" class="form-label">Teléfono</label>
+                    <input type="text" id="telefono_txt" class="form-control" readonly>
+                </div>
+                <div class="col-md-3">
+                    <label for="direccion_txt" class="form-label">Dirección</label>
+                    <input type="text" id="direccion_txt" class="form-control" readonly>
+                </div>
+                <div class="col-md-3">
+                    <label for="estado_lst" class="form-label">Estado</label>
+                    <select id="estado_lst" class="form-select">
+                        <option value="PENDIENTE">Pendiente</option>
+                        <option value="CERRADA">Cerrada</option>
+                    </select>
+                </div>
+                <div class="col-md-9">
+                    <label for="observaciones_txt" class="form-label">Observaciones</label>
+                    <input type="text" id="observaciones_txt" class="form-control">
+                </div>
+            </div>
+            <hr class="my-4">
+            <div class="row g-3">
+                <div class="col-md-2">
+                    <label for="marca_txt" class="form-label">Marca</label>
+                    <input type="text" id="marca_txt" class="form-control">
+                </div>
+                <div class="col-md-2">
+                    <label for="modelo_txt" class="form-label">Modelo</label>
+                    <input type="text" id="modelo_txt" class="form-control">
+                </div>
+                <div class="col-md-2">
+                    <label for="numero_serie_txt" class="form-label">N° Serie</label>
+                    <input type="text" id="numero_serie_txt" class="form-control">
+                </div>
+                <div class="col-md-3">
+                    <label for="falla_txt" class="form-label">Falla Reportada</label>
+                    <input type="text" id="falla_txt" class="form-control">
+                </div>
+                <div class="col-md-3">
+                    <label for="accesorios_txt" class="form-label">Accesorios Entregados</label>
+                    <input type="text" id="accesorios_txt" class="form-control">
+                </div>
+                <div class="col-md-3">
+                    <label for="diagnostico_txt" class="form-label">Diagnóstico Preliminar</label>
+                    <input type="text" id="diagnostico_txt" class="form-control">
+                </div>
+                <div class="col-md-3">
+                    <label for="estado_equipo_lst" class="form-label">Estado del Equipo</label>
+                    <select id="estado_equipo_lst" class="form-select">
+                        <option value="">-- Seleccione --</option>
+                        <option value="En diagnóstico">En diagnóstico</option>
+                        <option value="Listo">Listo</option>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label for="observaciones_detalle_txt" class="form-label">Observaciones</label>
+                    <input type="text" id="observaciones_detalle_txt" class="form-control">
+                </div>
+                <div class="col-md-3 d-grid align-items-end">
+                    <button class="btn btn-primary" onclick="agregarDetalleRecepcion(); return false;">
+                        <i class="bi bi-plus-lg"></i> Agregar Equipo
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="card-footer text-end">
+            <button class="btn btn-success me-2" onclick="guardarRecepcion(); return false;">
+                <i class="bi bi-save"></i> Guardar
+            </button>
+            <button class="btn btn-danger" onclick="mostrarListarRecepcion(); return false;">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="container mt-4">
+    <div class="table-responsive">
+        <table class="table table-bordered text-center align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>Marca</th>
+                    <th>Modelo</th>
+                    <th>N° Serie</th>
+                    <th>Estado</th>
+                    <th>Acción</th>
+                </tr>
+            </thead>
+            <tbody id="detalle_recepcion_tb"></tbody>
+        </table>
+    </div>
+</div>

--- a/paginas/referenciales/recepcion/listar.php
+++ b/paginas/referenciales/recepcion/listar.php
@@ -1,0 +1,41 @@
+<div class="container mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">Listado de Recepciones</h4>
+        <button class="btn btn-primary" onclick="mostrarAgregarRecepcion(); return false;">
+            <i class="bi bi-plus-circle"></i> Agregar
+        </button>
+    </div>
+    <div class="card shadow-sm rounded-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-8">
+                    <label for="b_recepcion" class="form-label">Buscador</label>
+                    <input type="text" id="b_recepcion" class="form-control" placeholder="Buscar por cliente...">
+                </div>
+                <div class="col-md-4">
+                    <button class="btn btn-secondary w-100" onclick="buscarRecepcion(); return false;">
+                        <i class="bi bi-search"></i> Buscar
+                    </button>
+                </div>
+            </div>
+            <div class="table-responsive mt-4">
+                <table class="table table-bordered table-hover align-middle text-center">
+                    <thead class="table-light">
+                        <tr>
+                            <th>#</th>
+                            <th>Fecha</th>
+                            <th>Cliente</th>
+                            <th>Teléfono</th>
+                            <th>Dirección</th>
+                            <th>Estado</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="recepcion_datos_tb">
+                        <!-- Contenido dinámico -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/utcdp1.sql
+++ b/utcdp1.sql
@@ -675,3 +675,48 @@ ALTER TABLE `detalle_nota_credito`
   ADD CONSTRAINT `detalle_nota_credito_ibfk_2` FOREIGN KEY (`id_producto`) REFERENCES `productos` (`producto_id`);
 ALTER TABLE `motivo_item_nota_credito`
   ADD CONSTRAINT `motivo_item_nota_credito_ibfk_1` FOREIGN KEY (`id_detalle`) REFERENCES `detalle_nota_credito` (`id_detalle`);
+
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `recepcion`
+--
+CREATE TABLE `recepcion` (
+  `id_recepcion` int(11) NOT NULL AUTO_INCREMENT,
+  `fecha_recepcion` date NOT NULL,
+  `id_cliente` int(11) NOT NULL,
+  `nombre_cliente` varchar(100) NOT NULL,
+  `telefono` varchar(20) DEFAULT NULL,
+  `direccion` varchar(255) DEFAULT NULL,
+  `estado` varchar(20) NOT NULL,
+  `observaciones` text DEFAULT NULL,
+  PRIMARY KEY (`id_recepcion`),
+  KEY `id_cliente` (`id_cliente`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `recepcion_detalle`
+--
+CREATE TABLE `recepcion_detalle` (
+  `id_detalle` int(11) NOT NULL AUTO_INCREMENT,
+  `id_recepcion` int(11) NOT NULL,
+  `marca` varchar(50) DEFAULT NULL,
+  `modelo` varchar(50) DEFAULT NULL,
+  `numero_serie` varchar(100) DEFAULT NULL,
+  `falla_reportada` text DEFAULT NULL,
+  `accesorios_entregados` text DEFAULT NULL,
+  `diagnostico_preliminar` text DEFAULT NULL,
+  `estado_equipo` varchar(20) DEFAULT NULL,
+  `observaciones_detalle` text DEFAULT NULL,
+  PRIMARY KEY (`id_detalle`),
+  KEY `id_recepcion` (`id_recepcion`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Filtros para las tablas de recepcion
+--
+ALTER TABLE `recepcion`
+  ADD CONSTRAINT `recepcion_ibfk_1` FOREIGN KEY (`id_cliente`) REFERENCES `clientes` (`id_cliente`);
+ALTER TABLE `recepcion_detalle`
+  ADD CONSTRAINT `recepcion_detalle_ibfk_1` FOREIGN KEY (`id_recepcion`) REFERENCES `recepcion` (`id_recepcion`);

--- a/vistas/recepcion.js
+++ b/vistas/recepcion.js
@@ -1,0 +1,227 @@
+let detallesRecepcion = [];
+let listaClientes = [];
+
+function mostrarListarRecepcion(){
+    let contenido = dameContenido("paginas/referenciales/recepcion/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaRecepcion();
+}
+window.mostrarListarRecepcion = mostrarListarRecepcion;
+
+function mostrarAgregarRecepcion(){
+    let contenido = dameContenido("paginas/referenciales/recepcion/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaClientes();
+    detallesRecepcion = [];
+    renderDetallesRecepcion();
+}
+window.mostrarAgregarRecepcion = mostrarAgregarRecepcion;
+
+function cargarListaClientes(){
+    let datos = ejecutarAjax("controladores/cliente.php","leer=1");
+    if(datos !== "0"){
+        listaClientes = JSON.parse(datos);
+        renderListaClientes(listaClientes);
+    }
+}
+
+function renderListaClientes(arr){
+    let select = $("#id_cliente_lst");
+    select.html('<option value="">-- Seleccione un cliente --</option>');
+    arr.forEach(c => select.append(`<option value="${c.id_cliente}" data-telefono="${c.telefono}" data-direccion="${c.direccion}">${c.nombre_apellido}</option>`));
+}
+
+$(document).on('change','#id_cliente_lst', function(){
+    let tel = $("#id_cliente_lst option:selected").data('telefono') || '';
+    let dir = $("#id_cliente_lst option:selected").data('direccion') || '';
+    $("#telefono_txt").val(tel);
+    $("#direccion_txt").val(dir);
+});
+
+function agregarDetalleRecepcion(){
+    if($("#marca_txt").val().trim().length===0){mensaje_dialogo_info_ERROR("Debe ingresar la marca","ERROR");return;}
+    if($("#modelo_txt").val().trim().length===0){mensaje_dialogo_info_ERROR("Debe ingresar el modelo","ERROR");return;}
+    if($("#numero_serie_txt").val().trim().length===0){mensaje_dialogo_info_ERROR("Debe ingresar el número de serie","ERROR");return;}
+    if($("#falla_txt").val().trim().length===0){mensaje_dialogo_info_ERROR("Debe ingresar la falla reportada","ERROR");return;}
+
+    let detalle = {
+        marca: $("#marca_txt").val().trim(),
+        modelo: $("#modelo_txt").val().trim(),
+        numero_serie: $("#numero_serie_txt").val().trim(),
+        falla_reportada: $("#falla_txt").val().trim(),
+        accesorios_entregados: $("#accesorios_txt").val().trim(),
+        diagnostico_preliminar: $("#diagnostico_txt").val().trim(),
+        estado_equipo: $("#estado_equipo_lst").val(),
+        observaciones_detalle: $("#observaciones_detalle_txt").val().trim()
+    };
+    detallesRecepcion.push(detalle);
+    renderDetallesRecepcion();
+    limpiarDetalleRecepcionForm();
+}
+window.agregarDetalleRecepcion = agregarDetalleRecepcion;
+
+function limpiarDetalleRecepcionForm(){
+    $("#marca_txt").val('');
+    $("#modelo_txt").val('');
+    $("#numero_serie_txt").val('');
+    $("#falla_txt").val('');
+    $("#accesorios_txt").val('');
+    $("#diagnostico_txt").val('');
+    $("#estado_equipo_lst").val('');
+    $("#observaciones_detalle_txt").val('');
+}
+
+function renderDetallesRecepcion(){
+    let tbody = $("#detalle_recepcion_tb");
+    tbody.html('');
+    detallesRecepcion.forEach((d,i)=>{
+        tbody.append(`<tr>
+            <td>${d.marca}</td>
+            <td>${d.modelo}</td>
+            <td>${d.numero_serie}</td>
+            <td>${d.estado_equipo}</td>
+            <td><button class="btn btn-danger btn-sm" onclick="eliminarDetalleRecepcion(${i}); return false;"><i class="bi bi-trash"></i></button></td>
+        </tr>`);
+    });
+}
+
+function eliminarDetalleRecepcion(index){
+    detallesRecepcion.splice(index,1);
+    renderDetallesRecepcion();
+}
+window.eliminarDetalleRecepcion = eliminarDetalleRecepcion;
+
+function guardarRecepcion(){
+    if($("#id_cliente_lst").val()===""){mensaje_dialogo_info_ERROR("Debe seleccionar un cliente","ERROR");return;}
+    if($("#fecha_txt").val().trim().length===0){mensaje_dialogo_info_ERROR("Debe ingresar la fecha","ERROR");return;}
+    if(detallesRecepcion.length===0){mensaje_dialogo_info_ERROR("Debe agregar al menos un equipo","ERROR");return;}
+
+    let datos = {
+        fecha_recepcion: $("#fecha_txt").val(),
+        id_cliente: $("#id_cliente_lst").val(),
+        nombre_cliente: $("#id_cliente_lst option:selected").text(),
+        telefono: $("#telefono_txt").val(),
+        direccion: $("#direccion_txt").val(),
+        estado: $("#estado_lst").val(),
+        observaciones: $("#observaciones_txt").val()
+    };
+
+    let idRecepcion = $("#id_recepcion").val();
+    if(idRecepcion === "0"){
+        idRecepcion = ejecutarAjax("controladores/recepcion.php","guardar="+JSON.stringify(datos));
+        detallesRecepcion.forEach(function(d){
+            let det = {...d, id_recepcion:idRecepcion};
+            ejecutarAjax("controladores/detalle_recepcion.php","guardar="+JSON.stringify(det));
+        });
+    }else{
+        datos = {...datos, id_recepcion:idRecepcion};
+        ejecutarAjax("controladores/recepcion.php","actualizar="+JSON.stringify(datos));
+        ejecutarAjax("controladores/detalle_recepcion.php","eliminar_por_recepcion="+idRecepcion);
+        detallesRecepcion.forEach(function(d){
+            let det = {...d, id_recepcion:idRecepcion};
+            ejecutarAjax("controladores/detalle_recepcion.php","guardar="+JSON.stringify(det));
+        });
+    }
+    mensaje_confirmacion("Guardado correctamente");
+    mostrarListarRecepcion();
+}
+window.guardarRecepcion = guardarRecepcion;
+
+function cargarTablaRecepcion(){
+    let datos = ejecutarAjax("controladores/recepcion.php","leer=1");
+    if(datos === "0"){
+        $("#recepcion_datos_tb").html("NO HAY REGISTROS");
+    }else{
+        let json = JSON.parse(datos);
+        $("#recepcion_datos_tb").html('');
+        json.map(function(it){
+            $("#recepcion_datos_tb").append(`
+                <tr>
+                    <td>${it.id_recepcion}</td>
+                    <td>${it.fecha_recepcion}</td>
+                    <td>${it.nombre_cliente}</td>
+                    <td>${it.telefono}</td>
+                    <td>${it.direccion}</td>
+                    <td>${badgeEstado(it.estado)}</td>
+                    <td>
+                        <button class="btn btn-warning btn-sm editar-recepcion" title="Editar"><i class="bi bi-pencil-square"></i></button>
+                        <button class="btn btn-danger btn-sm cerrar-recepcion" title="Cerrar"><i class="bi bi-x-circle"></i></button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+
+function buscarRecepcion(){
+    let b = $("#b_recepcion").val();
+    let datos = ejecutarAjax("controladores/recepcion.php","leer_descripcion="+b);
+    if(datos === "0"){
+        $("#recepcion_datos_tb").html("NO HAY REGISTROS");
+    }else{
+        let json = JSON.parse(datos);
+        $("#recepcion_datos_tb").html('');
+        json.map(function(it){
+            $("#recepcion_datos_tb").append(`
+                <tr>
+                    <td>${it.id_recepcion}</td>
+                    <td>${it.fecha_recepcion}</td>
+                    <td>${it.nombre_cliente}</td>
+                    <td>${it.telefono}</td>
+                    <td>${it.direccion}</td>
+                    <td>${badgeEstado(it.estado)}</td>
+                    <td>
+                        <button class="btn btn-warning btn-sm editar-recepcion" title="Editar"><i class="bi bi-pencil-square"></i></button>
+                        <button class="btn btn-danger btn-sm cerrar-recepcion" title="Cerrar"><i class="bi bi-x-circle"></i></button>
+                    </td>
+                </tr>`);
+        });
+    }
+}
+window.buscarRecepcion = buscarRecepcion;
+
+$(document).on("click",".editar-recepcion",function(){
+    let id=$(this).closest("tr").find("td:eq(0)").text();
+    mostrarAgregarRecepcion();
+    setTimeout(function(){
+        let datos = ejecutarAjax("controladores/recepcion.php","leer_id="+id);
+        let json = JSON.parse(datos);
+        $("#id_recepcion").val(json.id_recepcion);
+        $("#fecha_txt").val(json.fecha_recepcion);
+        $("#observaciones_txt").val(json.observaciones);
+        $("#estado_lst").val(json.estado);
+        cargarListaClientes();
+        setTimeout(function(){
+            $("#id_cliente_lst").val(json.id_cliente);
+            $("#telefono_txt").val(json.telefono);
+            $("#direccion_txt").val(json.direccion);
+        },100);
+        let det = ejecutarAjax("controladores/detalle_recepcion.php","leer=1&id_recepcion="+id);
+        if(det !== "0"){
+            detallesRecepcion = JSON.parse(det);
+        }else{
+            detallesRecepcion = [];
+        }
+        renderDetallesRecepcion();
+    },100);
+});
+
+$(document).on("click",".cerrar-recepcion",function(){
+    let id=$(this).closest("tr").find("td:eq(0)").text();
+    Swal.fire({
+        title:"¿Cerrar recepción?",
+        text:"Esta acción marcará la recepción como cerrada.",
+        icon:"warning",
+        showCancelButton:true,
+        confirmButtonText:"Sí, cerrar",
+        cancelButtonText:"Cancelar",
+        confirmButtonColor:"#dc3545",
+        cancelButtonColor:"#6c757d",
+        reverseButtons:true
+    }).then((result)=>{
+        if(result.isConfirmed){
+            ejecutarAjax("controladores/recepcion.php","cerrar="+id);
+            mensaje_confirmacion("Recepción cerrada");
+            cargarTablaRecepcion();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add recepcion and recepcion_detalle tables
- implement PHP controllers for recepcion and its details
- add pages and JavaScript to manage full recepcion CRUD

## Testing
- `php -l controladores/recepcion.php`
- `php -l controladores/detalle_recepcion.php`


------
https://chatgpt.com/codex/tasks/task_e_68967b4ec1208325b4456e13ee0adf31