### PR TITLE
Add print support for remisiones and default emitted state

### DIFF
--- a/controladores/remision.php
+++ b/controladores/remision.php
@@ -4,12 +4,19 @@ require_once '../conexion/db.php';
 // GUARDAR REMISION
 if (isset($_POST['guardar'])) {
     $datos = json_decode($_POST['guardar'], true);
+    // Siempre guardar la remisión con estado EMITIDO
+    $datos['estado'] = 'EMITIDO';
     $db = new DB();
     $cn = $db->conectar();
     $query = $cn->prepare(
         "INSERT INTO remision (id_cliente, fecha_remision, observacion, estado) VALUES (:id_cliente, :fecha_remision, :observacion, :estado)"
     );
-    $query->execute($datos);
+    $query->execute([
+        'id_cliente' => $datos['id_cliente'],
+        'fecha_remision' => $datos['fecha_remision'],
+        'observacion' => $datos['observacion'],
+        'estado' => $datos['estado']
+    ]);
     echo $cn->lastInsertId();
 }
 

--- a/paginas/referenciales/remision/agregar.php
+++ b/paginas/referenciales/remision/agregar.php
@@ -1,6 +1,6 @@
 <div class="container mt-4">
     <input type="hidden" id="id_remision" value="0">
-    <input type="hidden" id="estado_txt" value="PENDIENTE">
+    <input type="hidden" id="estado_txt" value="EMITIDO">
     <div class="card shadow rounded-4">
         <div class="card-header bg-primary text-white rounded-top-4">
             <h4 class="mb-0">Agregar / Editar Remisión</h4>

--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -185,6 +185,7 @@ function cargarTablaRemision(){
                     <td>${formatearPY(it.total)}</td>
                     <td>${badgeEstado(it.estado)}</td>
                     <td>
+                        <button class="btn btn-info btn-sm imprimir-remision" title="Imprimir"><i class="bi bi-printer"></i></button>
                         <button class="btn btn-warning btn-sm editar-remision" title="Editar"><i class="bi bi-pencil-square"></i></button>
                         <button class="btn btn-danger btn-sm anular-remision" title="Anular"><i class="bi bi-x-circle"></i></button>
                     </td>
@@ -210,6 +211,7 @@ function buscarRemision(){
                     <td>${formatearPY(it.total)}</td>
                     <td>${badgeEstado(it.estado)}</td>
                     <td>
+                        <button class="btn btn-info btn-sm imprimir-remision" title="Imprimir"><i class="bi bi-printer"></i></button>
                         <button class="btn btn-warning btn-sm editar-remision" title="Editar"><i class="bi bi-pencil-square"></i></button>
                         <button class="btn btn-danger btn-sm anular-remision" title="Anular"><i class="bi bi-x-circle"></i></button>
                     </td>
@@ -218,6 +220,56 @@ function buscarRemision(){
     }
 }
 window.buscarRemision = buscarRemision;
+
+function imprimirRemision(id){
+    let datos = ejecutarAjax("controladores/remision.php","leer_id="+id);
+    if(datos === "0"){ alert("Remisión no encontrada"); return; }
+    let rem = JSON.parse(datos);
+    let detData = ejecutarAjax("controladores/detalle_remision.php","leer=1&id_remision="+id);
+    let detalles = detData === "0" ? [] : JSON.parse(detData);
+    let filas = detalles.map((d,i)=>`<tr>
+            <td>${i+1}</td>
+            <td>${d.producto}</td>
+            <td>${d.cantidad}</td>
+            <td>${formatearPY(d.precio_unitario)}</td>
+            <td>${formatearPY(d.subtotal)}</td>
+        </tr>`).join('');
+    let win = window.open('', '', 'width=900,height=700');
+    win.document.write(`
+    <html>
+    <head>
+        <title>Remisión #${rem.id_remision}</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    </head>
+    <body>
+        <div class="container mt-4">
+            <h2 class="text-center mb-4">Remisión N° ${rem.id_remision}</h2>
+            <p><strong>Fecha:</strong> ${rem.fecha_remision}</p>
+            <p><strong>Cliente:</strong> ${rem.cliente}</p>
+            <p><strong>Observación:</strong> ${rem.observacion || ''}</p>
+            <p><strong>Estado:</strong> ${rem.estado}</p>
+            <table class="table table-bordered mt-4">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Producto</th>
+                        <th>Cantidad</th>
+                        <th>Precio</th>
+                        <th>Subtotal</th>
+                    </tr>
+                </thead>
+                <tbody>${filas}</tbody>
+            </table>
+            <h4 class="text-end">Total: ${formatearPY(rem.total)}</h4>
+        </div>
+    </body>
+    </html>
+    `);
+    win.document.close();
+    win.focus();
+    win.print();
+}
+window.imprimirRemision = imprimirRemision;
 
 $(document).on("click",".editar-remision",function(){
     let id=$(this).closest("tr").find("td:eq(0)").text();
@@ -260,4 +312,9 @@ $(document).on("click",".anular-remision",function(){
             cargarTablaRemision();
         }
     });
+});
+
+$(document).on("click",".imprimir-remision",function(){
+    let id=$(this).closest("tr").find("td:eq(0)").text();
+    imprimirRemision(id);
 });


### PR DESCRIPTION
## Summary
- add default EMITIDO state when creating a remisión
- allow printing individual remisiones from listing

## Testing
- `php -l controladores/remision.php`
- `php -l paginas/referenciales/remision/agregar.php`
- `node --check vistas/remision.js`


------
https://chatgpt.com/codex/tasks/task_e_6897a6407d548325a0f89057f3cd1ffa