### PR TITLE
Fix order total and subtotal calculation

### DIFF
--- a/paginas/referenciales/orden_compra/agregar.php
+++ b/paginas/referenciales/orden_compra/agregar.php
@@ -137,38 +137,6 @@
   </div>
 </div>
 
-<!-- Helpers: formato y cálculo rápido -->
-<script>
-  function formatearPY(n) {
-    return new Intl.NumberFormat('es-PY', { minimumFractionDigits: 0 }).format(Math.round(n || 0));
-  }
-
-  // Calcula y muestra el subtotal al tipear
-  $(document).on('input', '#cantidad_txt, #precio_unitario_txt', function () {
-    const cant = parseFloat($('#cantidad_txt').val()) || 0;
-    const precio = parseFloat($('#precio_unitario_txt').val()) || 0;
-    const subtotal = cant * precio;
-    $('#subtotal_txt').val(formatearPY(subtotal));
-  });
-
-  // Función opcional para que puedas actualizar el total mostrado
-  // Llamala después de renderizar las filas en #detalle_oc_tb
-  function actualizarTotalOC() {
-    let total = 0;
-    $('#detalle_oc_tb tr').each(function(){
-      const celda = $(this).find('[data-subtotal], .subtotal-celda').first();
-      let valor = 0;
-      if (celda.length) {
-        // Si guardas el valor "crudo" en data-subtotal, úsalo
-        const ds = celda.attr('data-subtotal');
-        valor = ds ? parseFloat(ds) || 0 : (parseFloat(celda.text().replace(/\./g,'')) || 0);
-      }
-      total += valor;
-    });
-    $('#total_oc_txt').val(formatearPY(total));
-  }
-</script>
-
 <!-- Ajustes finos -->
 <style>
   .card { overflow: hidden; }

--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -21,7 +21,8 @@ function setTotalUI(total) {
     '#total_txt', '#total_lbl',
     '#total_orden_txt', '#total_orden_lbl',
     '#total_general', '#total_general_lbl',
-    '#total', '#total_orden'
+    '#total', '#total_orden',
+    '#total_oc_txt'
   ];
   ids.forEach(sel => {
     const $el = $(sel);


### PR DESCRIPTION
## Summary
- Ensure purchase order totals update correctly by including `#total_oc_txt` in UI refresh
- Remove obsolete inline helpers that misparsed formatted prices, fixing subtotal field

## Testing
- `node --check vistas/orden_compra.js`
- `php -l paginas/referenciales/orden_compra/agregar.php`


------
https://chatgpt.com/codex/tasks/task_e_689a0382f55c8325b9232e26008acd45