### PR TITLE
Fix pricing input and duplicate validation in remisiones

### DIFF
--- a/paginas/referenciales/remision/agregar.php
+++ b/paginas/referenciales/remision/agregar.php
@@ -31,11 +31,11 @@
                 </div>
                 <div class="col-md-2">
                     <label for="precio_unitario_txt" class="form-label">Precio Unitario</label>
-                    <input type="number" id="precio_unitario_txt" class="form-control" min="0.01" step="0.01">
+                    <input type="text" id="precio_unitario_txt" class="form-control" inputmode="decimal">
                 </div>
                 <div class="col-md-2">
                     <label for="subtotal_txt" class="form-label">Subtotal</label>
-                    <input type="number" id="subtotal_txt" class="form-control" readonly>
+                    <input type="text" id="subtotal_txt" class="form-control" readonly>
                 </div>
                 <div class="col-md-2 d-grid align-items-end">
                     <button class="btn btn-primary" onclick="agregarDetalleRemision(); return false;">


### PR DESCRIPTION
## Summary
- Allow entering large unit prices and show formatted subtotal in remisiones
- Prevent adding duplicate products to remision details

## Testing
- `php -l paginas/referenciales/remision/agregar.php`
- `node --check vistas/remision.js`


------
https://chatgpt.com/codex/tasks/task_e_689a0467b2b08325befe9d2cb82a73e0