### PR TITLE
Fix credit note price handling for large numbers

### DIFF
--- a/paginas/referenciales/nota_credito/agregar.php
+++ b/paginas/referenciales/nota_credito/agregar.php
@@ -65,7 +65,7 @@
             <label for="precio_unitario_txt" class="form-label">Precio Unitario</label>
             <div class="input-group">
               <span class="input-group-text">Gs.</span>
-              <input type="number" id="precio_unitario_txt" class="form-control text-end" min="0.01" step="0.01" placeholder="0">
+              <input type="text" id="precio_unitario_txt" class="form-control text-end" placeholder="0">
             </div>
           </div>
         </div>
@@ -75,7 +75,7 @@
             <label for="subtotal_txt" class="form-label">Subtotal</label>
             <div class="input-group">
               <span class="input-group-text">Gs.</span>
-              <input type="number" id="subtotal_txt" class="form-control text-end" readonly>
+              <input type="text" id="subtotal_txt" class="form-control text-end" readonly>
             </div>
           </div>
           <div class="col-12 col-md-5">

--- a/vistas/nota_credito.js
+++ b/vistas/nota_credito.js
@@ -57,11 +57,29 @@ $(document).on('change','#id_producto_lst',function(){
     $('#descripcion_txt').val(desc);
 });
 
-$(document).on('input','#cantidad_txt, #precio_unitario_txt', function(){
+function obtenerPrecioUnitario(){
+    return quitarDecimalesConvertir(String($('#precio_unitario_txt').val() || '0')) || 0;
+}
+
+function actualizarSubtotalNC(){
     const cant = parseFloat($('#cantidad_txt').val()) || 0;
-    const precio = parseFloat($('#precio_unitario_txt').val()) || 0;
+    const precio = obtenerPrecioUnitario();
     const subtotal = cant * precio;
     $('#subtotal_txt').val(formatearPY(subtotal));
+}
+
+$(document).on('input','#cantidad_txt', actualizarSubtotalNC);
+
+$(document).on('input','#precio_unitario_txt', function(){
+    const raw = String($(this).val());
+    const digits = raw.replace(/\D/g, '');
+    if (digits.length === 0) {
+        $(this).val('');
+    } else {
+        const n = parseInt(digits,10) || 0;
+        $(this).val(formatearPY(n));
+    }
+    actualizarSubtotalNC();
 });
 
 function agregarDetalleNotaCredito(){
@@ -69,7 +87,7 @@ function agregarDetalleNotaCredito(){
     if($("#cantidad_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar la cantidad","ERROR");return;}
     if(parseFloat($("#cantidad_txt").val()) <= 0){mensaje_dialogo_info_ERROR("La cantidad debe ser mayor que 0","ERROR");return;}
     if($("#precio_unitario_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar el precio","ERROR");return;}
-    if(parseFloat($("#precio_unitario_txt").val()) <= 0){mensaje_dialogo_info_ERROR("El precio debe ser mayor que 0","ERROR");return;}
+    if(obtenerPrecioUnitario() <= 0){mensaje_dialogo_info_ERROR("El precio debe ser mayor que 0","ERROR");return;}
 
    
     const motivoItem = $("#motivo_item_txt").val().trim();
@@ -79,14 +97,17 @@ function agregarDetalleNotaCredito(){
         return;
     }
 
+    const cantidad = parseFloat($("#cantidad_txt").val()) || 0;
+    const precio = obtenerPrecioUnitario();
+    const subtotal = cantidad * precio;
     let detalle = {
         id_producto: $("#id_producto_lst").val(),
         producto: $("#id_producto_lst option:selected").text(),
         descripcion: $("#descripcion_txt").val(),
-        cantidad: $("#cantidad_txt").val(),
-        precio_unitario: $("#precio_unitario_txt").val(),
-        subtotal: (parseFloat($("#cantidad_txt").val()) || 0) * (parseFloat($("#precio_unitario_txt").val()) || 0),
-        total_linea: (parseFloat($("#cantidad_txt").val()) || 0) * (parseFloat($("#precio_unitario_txt").val()) || 0),
+        cantidad: cantidad,
+        precio_unitario: precio,
+        subtotal: subtotal,
+        total_linea: subtotal,
         motivo: motivoItem, // 👈 queda guardado
         observacion: $("#observacion_txt").val()
     };


### PR DESCRIPTION
## Summary
- Allow large unit prices in credit notes by switching price and subtotal inputs to plain text
- Add parsing and formatting logic to preserve thousands separators and compute subtotals correctly

## Testing
- `node --check vistas/nota_credito.js`
- `php -l paginas/referenciales/nota_credito/agregar.php`


------
https://chatgpt.com/codex/tasks/task_e_689a057fd4188325ab0c4b33a1d3b8df