### PR TITLE
Corrige campos de precio en orden de compra

### DIFF
--- a/paginas/referenciales/orden_compra/agregar.php
+++ b/paginas/referenciales/orden_compra/agregar.php
@@ -59,7 +59,7 @@
 
         <div class="col-md-2">
           <div class="form-floating">
-            <input type="number" step="0.01" id="precio_unitario_txt" class="form-control" inputmode="decimal" placeholder="Precio Unitario">
+            <input type="text" id="precio_unitario_txt" class="form-control" inputmode="decimal" placeholder="Precio Unitario">
             <label for="precio_unitario_txt">Precio Unitario</label>
           </div>
         </div>

--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -37,7 +37,7 @@ function actualizarSubtotalUI() {
   const cant = getCantidad();
   const precio = getPrecioUnitario();
   const subtotal = cant * precio;
-  $('#subtotal_txt').val(formatearPY(subtotal)); // mostrar con puntos
+  $('#subtotal_txt').val(subtotal ? formatearPY(subtotal) : '');
 }
 
 function calcularTotalOrdenLocal() {


### PR DESCRIPTION
## Summary
- Ajusta el campo de precio unitario a texto para permitir números grandes con formato.
- Sincroniza el cálculo de subtotal con la lógica usada en remisión.

## Testing
- `php -l paginas/referenciales/orden_compra/agregar.php`
- `node --check vistas/orden_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_689a09767da88325b02a8a95748ccf59