### PR TITLE
Evita productos duplicados en nota de crédito

### DIFF
--- a/vistas/nota_credito.js
+++ b/vistas/nota_credito.js
@@ -89,7 +89,11 @@ function agregarDetalleNotaCredito(){
     if($("#precio_unitario_txt").val().trim().length === 0){mensaje_dialogo_info_ERROR("Debe ingresar el precio","ERROR");return;}
     if(obtenerPrecioUnitario() <= 0){mensaje_dialogo_info_ERROR("El precio debe ser mayor que 0","ERROR");return;}
 
-   
+    if(detallesNota.some(d => d.id_producto === $("#id_producto_lst").val())){
+        mensaje_dialogo_info_ERROR("El producto ya fue agregado","ERROR");
+        return;
+    }
+
     const motivoItem = $("#motivo_item_txt").val().trim();
     if(motivoItem.length === 0){
         mensaje_dialogo_info_ERROR("Debe ingresar el motivo del ítem","ERROR");


### PR DESCRIPTION
## Summary
- Impide que un mismo producto sea agregado más de una vez en la nota de crédito.

## Testing
- `node --check vistas/nota_credito.js`


------
https://chatgpt.com/codex/tasks/task_e_689a0cfd75e88325a514a0973fb1e7b6