### PR TITLE
Ocultar equipos ya diagnosticados

### DIFF
--- a/controladores/detalle_recepcion.php
+++ b/controladores/detalle_recepcion.php
@@ -42,6 +42,13 @@ if (isset($_POST['leer'])) {
     if (!empty($_POST['id_recepcion'])) {
         $sql .= " WHERE id_recepcion = :id_recepcion";
         $params['id_recepcion'] = $_POST['id_recepcion'];
+
+        if (!empty($_POST['sin_diagnostico'])) {
+            $sql .= " AND id_detalle NOT IN (SELECT id_detalle_recepcion FROM diagnostico WHERE id_recepcion = :id_recepcion)";
+        }
+    } elseif (!empty($_POST['sin_diagnostico'])) {
+        // Filtrar sin diagnóstico para todas las recepciones
+        $sql .= " WHERE id_detalle NOT IN (SELECT id_detalle_recepcion FROM diagnostico)";
     }
     $sql .= " ORDER BY id_detalle DESC";
     $query = $cn->prepare($sql);

--- a/vistas/diagnostico.js
+++ b/vistas/diagnostico.js
@@ -6,7 +6,7 @@ function mostrarAgregarDiagnostico(){let c=dameContenido("paginas/referenciales/
 window.mostrarAgregarDiagnostico=mostrarAgregarDiagnostico;
 
 function cargarListaRecepciones(selId=""){let d=ejecutarAjax("controladores/recepcion.php","leer=1"),$s=$("#id_recepcion_lst");$s.html('<option value="">-- Seleccione --</option>');if(d!=="0"){JSON.parse(d).forEach(r=>$s.append(`<option value="${r.id_recepcion}">${r.id_recepcion} - ${r.nombre_cliente}</option>`));if(selId)$s.val(selId);}}
-$(document).on("change","#id_recepcion_lst",function(){let id=$(this).val(),$s=$("#id_detalle_lst");$s.html('<option value="">-- Equipo --</option>');if(id){let det=ejecutarAjax("controladores/detalle_recepcion.php","leer=1&id_recepcion="+id);if(det!=="0")JSON.parse(det).forEach(d=>$s.append(`<option value="${d.id_detalle}">${d.nombre_equipo}</option>`));}});
+$(document).on("change","#id_recepcion_lst",function(){let id=$(this).val(),$s=$("#id_detalle_lst");$s.html('<option value="">-- Equipo --</option>');if(id){let det=ejecutarAjax("controladores/detalle_recepcion.php","leer=1&id_recepcion="+id+"&sin_diagnostico=1");if(det!=="0")JSON.parse(det).forEach(d=>$s.append(`<option value="${d.id_detalle}">${d.nombre_equipo}</option>`));}});
 
 function agregarDetalleDiagnostico(){
   if(!validarDetalleDiagnosticoForm()) return;


### PR DESCRIPTION
## Summary
- Evita mostrar en el diagnóstico los equipos de una recepción que ya cuentan con diagnóstico previo
- Añade parámetro `sin_diagnostico` en el controlador para filtrar los detalles

## Testing
- `php -l controladores/detalle_recepcion.php`
- `node --check vistas/diagnostico.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689a12e6b61c83258d43dee6a5d6f27d