### PR TITLE
Mark reception as diagnosed when all equipment have diagnostics

### DIFF
--- a/controladores/diagnostico.php
+++ b/controladores/diagnostico.php
@@ -1,19 +1,35 @@
 <?php
 require_once '../conexion/db.php';
 $db=new DB();$cn=$db->conectar();
+
+function actualizarEstadoRecepcion($cn,$id){
+ $q=$cn->prepare("SELECT COUNT(*) FROM recepcion_detalle WHERE id_recepcion=:id");
+ $q->execute(['id'=>$id]);$total=$q->fetchColumn();
+ $q=$cn->prepare("SELECT COUNT(*) FROM diagnostico WHERE id_recepcion=:id");
+ $q->execute(['id'=>$id]);$diag=$q->fetchColumn();
+ $estado=($total>0 && $total==$diag)?'DIAGNOSTICADO':'PENDIENTE';
+ $q=$cn->prepare("UPDATE recepcion SET estado=:e WHERE id_recepcion=:id");
+ $q->execute(['e'=>$estado,'id'=>$id]);
+}
+
 if(isset($_POST['guardar'])){
  $d=json_decode($_POST['guardar'],true);
  $d['costo_total_estimado']=$d['costo_mano_obra_estimado']+$d['costo_repuestos_estimado'];
  $q=$cn->prepare("INSERT INTO diagnostico (id_recepcion,id_detalle_recepcion,estado,descripcion_falla,tiempo_estimado_horas,costo_mano_obra_estimado,costo_repuestos_estimado,costo_total_estimado,aplica_garantia,observaciones,creado_por) VALUES (:id_recepcion,:id_detalle_recepcion,:estado,:descripcion_falla,:tiempo_estimado_horas,:costo_mano_obra_estimado,:costo_repuestos_estimado,:costo_total_estimado,:aplica_garantia,:observaciones,:creado_por)");
- $q->execute($d);echo $cn->lastInsertId();
+ $q->execute($d);$id=$cn->lastInsertId();actualizarEstadoRecepcion($cn,$d['id_recepcion']);echo $id;
 }
 if(isset($_POST['actualizar'])){
  $d=json_decode($_POST['actualizar'],true);
  $d['costo_total_estimado']=$d['costo_mano_obra_estimado']+$d['costo_repuestos_estimado'];
  $q=$cn->prepare("UPDATE diagnostico SET id_recepcion=:id_recepcion,id_detalle_recepcion=:id_detalle_recepcion,estado=:estado,descripcion_falla=:descripcion_falla,tiempo_estimado_horas=:tiempo_estimado_horas,costo_mano_obra_estimado=:costo_mano_obra_estimado,costo_repuestos_estimado=:costo_repuestos_estimado,costo_total_estimado=:costo_total_estimado,aplica_garantia=:aplica_garantia,observaciones=:observaciones,modificado_por=:modificado_por,modificado_en=NOW() WHERE id_diagnostico=:id_diagnostico");
- $q->execute($d);
+ $q->execute($d);actualizarEstadoRecepcion($cn,$d['id_recepcion']);
 }
-if(isset($_POST['eliminar'])){$q=$cn->prepare("DELETE FROM diagnostico WHERE id_diagnostico=:id");$q->execute(['id'=>$_POST['eliminar']]);}
+if(isset($_POST['eliminar'])){
+ $q=$cn->prepare("SELECT id_recepcion FROM diagnostico WHERE id_diagnostico=:id");
+ $q->execute(['id'=>$_POST['eliminar']]);$r=$q->fetch(PDO::FETCH_ASSOC);
+ $q=$cn->prepare("DELETE FROM diagnostico WHERE id_diagnostico=:id");
+ $q->execute(['id'=>$_POST['eliminar']]);if($r)actualizarEstadoRecepcion($cn,$r['id_recepcion']);
+}
 if(isset($_POST['leer'])){
  $q=$cn->prepare("SELECT d.id_diagnostico,d.id_recepcion,r.nombre_cliente,d.fecha_inicio,d.estado FROM diagnostico d JOIN recepcion r ON d.id_recepcion=r.id_recepcion ORDER BY d.id_diagnostico DESC");
  $q->execute();echo $q->rowCount()?json_encode($q->fetchAll(PDO::FETCH_OBJ)):'0';

--- a/vistas/util.js
+++ b/vistas/util.js
@@ -140,6 +140,8 @@ function badgeEstado(estado) {
         clase = 'success';
     } else if (est === 'PENDIENTE') {
         clase = 'warning text-dark';
+    } else if (est === 'DIAGNOSTICADO') {
+        clase = 'info';
     } else if (est === 'INACTIVO' || est === 'ANULADO') {
         clase = 'danger';
     }


### PR DESCRIPTION
## Summary
- update diagnostic controller to set reception state to `DIAGNOSTICADO` once every equipment has been diagnosed
- color `DIAGNOSTICADO` status with an info badge

## Testing
- `php -l controladores/diagnostico.php`
- `node --check vistas/util.js`


------
https://chatgpt.com/codex/tasks/task_e_689a18701cd883258e5deabef9d89d78