### PR TITLE
Show only pending receptions for diagnostics

### DIFF
--- a/controladores/recepcion.php
+++ b/controladores/recepcion.php
@@ -56,6 +56,22 @@ if (isset($_POST['leer'])) {
     echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
 
+// LISTAR RECEPCIONES PENDIENTES
+if (isset($_POST['leer_pendientes'])) {
+    $db = new DB();
+    $cn = $db->conectar();
+    $sql = "SELECT id_recepcion, nombre_cliente FROM recepcion WHERE estado = 'PENDIENTE'";
+    $params = [];
+    if (!empty($_POST['incluido'])) {
+        $sql .= " OR id_recepcion = :incluido";
+        $params['incluido'] = $_POST['incluido'];
+    }
+    $sql .= " ORDER BY id_recepcion DESC";
+    $query = $cn->prepare($sql);
+    $query->execute($params);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
 // LEER POR ID
 if (isset($_POST['leer_id'])) {
     $db = new DB();

--- a/vistas/diagnostico.js
+++ b/vistas/diagnostico.js
@@ -5,7 +5,7 @@ window.mostrarListarDiagnostico=mostrarListarDiagnostico;
 function mostrarAgregarDiagnostico(){let c=dameContenido("paginas/referenciales/diagnostico/agregar.php");$("#contenido-principal").html(c);detallesDiagnostico=[];cargarListaRecepciones();}
 window.mostrarAgregarDiagnostico=mostrarAgregarDiagnostico;
 
-function cargarListaRecepciones(selId=""){let d=ejecutarAjax("controladores/recepcion.php","leer=1"),$s=$("#id_recepcion_lst");$s.html('<option value="">-- Seleccione --</option>');if(d!=="0"){JSON.parse(d).forEach(r=>$s.append(`<option value="${r.id_recepcion}">${r.id_recepcion} - ${r.nombre_cliente}</option>`));if(selId)$s.val(selId);}}
+function cargarListaRecepciones(selId=""){let q="leer_pendientes=1";if(selId)q+="&incluido="+selId;let d=ejecutarAjax("controladores/recepcion.php",q),$s=$("#id_recepcion_lst");$s.html('<option value="">-- Seleccione --</option>');if(d!=="0"){JSON.parse(d).forEach(r=>$s.append(`<option value="${r.id_recepcion}">${r.id_recepcion} - ${r.nombre_cliente}</option>`));if(selId)$s.val(selId);}}
 $(document).on("change","#id_recepcion_lst",function(){let id=$(this).val(),$s=$("#id_detalle_lst");$s.html('<option value="">-- Equipo --</option>');if(id){let det=ejecutarAjax("controladores/detalle_recepcion.php","leer=1&id_recepcion="+id+"&sin_diagnostico=1");if(det!=="0")JSON.parse(det).forEach(d=>$s.append(`<option value="${d.id_detalle}">${d.nombre_equipo}</option>`));}});
 
 function agregarDetalleDiagnostico(){


### PR DESCRIPTION
## Summary
- List only pending receptions in diagnostic selector

## Testing
- `php -l controladores/recepcion.php`
- `node --check vistas/diagnostico.js`


------
https://chatgpt.com/codex/tasks/task_e_689a1b0984b08325951f0b71d08381c8