### PR TITLE
Fix diagnostic editing losing details and status updates

### DIFF
--- a/vistas/diagnostico.js
+++ b/vistas/diagnostico.js
@@ -1,8 +1,17 @@
 let detallesDiagnostico=[];
-function mostrarListarDiagnostico(){let c=dameContenido("paginas/referenciales/diagnostico/listar.php");$("#contenido-principal").html(c);cargarTablaDiagnostico();}
+function mostrarListarDiagnostico(){
+  let c=dameContenido("paginas/referenciales/diagnostico/listar.php");
+  $("#contenido-principal").html(c);
+  cargarTablaDiagnostico();
+}
 window.mostrarListarDiagnostico=mostrarListarDiagnostico;
 
-function mostrarAgregarDiagnostico(){let c=dameContenido("paginas/referenciales/diagnostico/agregar.php");$("#contenido-principal").html(c);detallesDiagnostico=[];cargarListaRecepciones();}
+function mostrarAgregarDiagnostico(reset=true){
+  let c=dameContenido("paginas/referenciales/diagnostico/agregar.php");
+  $("#contenido-principal").html(c);
+  if(reset)detallesDiagnostico=[];
+  cargarListaRecepciones();
+}
 window.mostrarAgregarDiagnostico=mostrarAgregarDiagnostico;
 
 function cargarListaRecepciones(selId=""){let q="leer_pendientes=1";if(selId)q+="&incluido="+selId;let d=ejecutarAjax("controladores/recepcion.php",q),$s=$("#id_recepcion_lst");$s.html('<option value="">-- Seleccione --</option>');if(d!=="0"){JSON.parse(d).forEach(r=>$s.append(`<option value="${r.id_recepcion}">${r.id_recepcion} - ${r.nombre_cliente}</option>`));if(selId)$s.val(selId);}}
@@ -238,7 +247,32 @@ window.imprimirDiagnostico = imprimirDiagnostico;
 
 function cargarTablaDiagnostico(filtro=""){let q=filtro?"leer_descripcion="+filtro:"leer=1",datos=ejecutarAjax("controladores/diagnostico.php",q);if(datos==="0"){$("#diagnostico_datos_tb").html("NO HAY REGISTROS");}else{let js=JSON.parse(datos);$("#diagnostico_datos_tb").html('');js.forEach(it=>{$("#diagnostico_datos_tb").append(`<tr><td>${it.id_diagnostico}</td><td>${it.id_recepcion} - ${it.nombre_cliente}</td><td>${it.fecha_inicio}</td><td>${badgeEstado(it.estado)}</td><td><button class="btn btn-secondary btn-sm imprimir-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-printer"></i></button> <button class="btn btn-warning btn-sm editar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-pencil-square"></i></button> <button class="btn btn-danger btn-sm eliminar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-trash"></i></button></td></tr>`);});}}
 
-function cargarDiagnostico(id){let d=ejecutarAjax("controladores/diagnostico.php","leer_id="+id);if(d!=='0'){let j=JSON.parse(d);mostrarAgregarDiagnostico();$("#id_diagnostico").val(j.id_diagnostico);$("#estado_lst").val(j.estado);$("#descripcion_falla_txt").val(j.descripcion_falla);$("#observaciones_txt").val(j.observaciones);$("#tiempo_txt").val(j.tiempo_estimado_horas);$("#costo_mano_txt").val(j.costo_mano_obra_estimado);$("#costo_repuestos_txt").val(j.costo_repuestos_estimado);$("#aplica_garantia_lst").val(j.aplica_garantia);cargarListaRecepciones(j.id_recepcion);let detRec=ejecutarAjax("controladores/detalle_recepcion.php","leer=1&id_recepcion="+j.id_recepcion);if(detRec!=='0'){let arr=JSON.parse(detRec),$s=$("#id_detalle_lst");arr.forEach(e=>$s.append(`<option value="${e.id_detalle}">${e.nombre_equipo}</option>`));$s.val(j.id_detalle_recepcion);}let det=ejecutarAjax("controladores/detalle_diagnostico.php","leer=1&id_diagnostico="+id);if(det!=='0'){detallesDiagnostico=JSON.parse(det);renderDetallesDiagnostico();}}}
+function cargarDiagnostico(id){
+  let d=ejecutarAjax("controladores/diagnostico.php","leer_id="+id);
+  if(d!=='0'){
+    let j=JSON.parse(d);
+    detallesDiagnostico=[];
+    let det=ejecutarAjax("controladores/detalle_diagnostico.php","leer=1&id_diagnostico="+id);
+    if(det!=='0')detallesDiagnostico=JSON.parse(det);
+    mostrarAgregarDiagnostico(false);
+    $("#id_diagnostico").val(j.id_diagnostico);
+    $("#estado_lst").val(j.estado);
+    $("#descripcion_falla_txt").val(j.descripcion_falla);
+    $("#observaciones_txt").val(j.observaciones);
+    $("#tiempo_txt").val(j.tiempo_estimado_horas);
+    $("#costo_mano_txt").val(j.costo_mano_obra_estimado);
+    $("#costo_repuestos_txt").val(j.costo_repuestos_estimado);
+    $("#aplica_garantia_lst").val(j.aplica_garantia);
+    cargarListaRecepciones(j.id_recepcion);
+    let detRec=ejecutarAjax("controladores/detalle_recepcion.php","leer=1&id_recepcion="+j.id_recepcion);
+    if(detRec!=='0'){
+      let arr=JSON.parse(detRec),$s=$("#id_detalle_lst");
+      arr.forEach(e=>$s.append(`<option value="${e.id_detalle}">${e.nombre_equipo}</option>`));
+      $s.val(j.id_detalle_recepcion);
+    }
+    renderDetallesDiagnostico();
+  }
+}
 $(document).on("click",".editar-diagnostico",function(){cargarDiagnostico($(this).data('id'));});
 $(document).on("click",".eliminar-diagnostico",function(){if(confirm("¿Eliminar?")){ejecutarAjax("controladores/diagnostico.php","eliminar="+$(this).data('id'));cargarTablaDiagnostico();}});
 $(document).on("click",".imprimir-diagnostico",function(){imprimirDiagnostico($(this).data('id'));});


### PR DESCRIPTION
## Summary
- Preserve component detail rows when editing diagnostics
- Refactor diagnostic loader to prefetch and render details while allowing status updates

## Testing
- `node --check final_UTD/vistas/diagnostico.js`


------
https://chatgpt.com/codex/tasks/task_e_689a20ac6ffc832590ffab9bedb37ef9