### PR TITLE
Fix cost formatting in purchase budgets

### DIFF
--- a/paginas/referenciales/presupuestos_compra/agregar.php
+++ b/paginas/referenciales/presupuestos_compra/agregar.php
@@ -139,11 +139,21 @@ function formatearPY(n) {
   return new Intl.NumberFormat('es-PY', { minimumFractionDigits: 0 }).format(Math.round(n || 0));
 }
 
-$(document).on('input', '#cantidad_txt, #precio_unitario_txt', function () {
+function recalcularSubtotal(){
   const cant = parseFloat($('#cantidad_txt').val()) || 0;
-  const precio = parseFloat($('#precio_unitario_txt').val()) || 0;
+  const precio = quitarDecimalesConvertir($('#precio_unitario_txt').val()) || 0;
   const subtotal = cant * precio;
-  $('#subtotal_txt').val(formatearPY(subtotal));
+  $('#subtotal_txt').val(subtotal ? formatearPY(subtotal) : '');
+}
+
+$(document).on('input', '#cantidad_txt', function(){
+  recalcularSubtotal();
+});
+
+$(document).on('input', '#precio_unitario_txt', function(){
+  const n = quitarDecimalesConvertir($(this).val());
+  $(this).val(n ? formatearPY(n) : '');
+  recalcularSubtotal();
 });
 </script>
 


### PR DESCRIPTION
## Summary
- sanitize unit cost inputs so thousands separators like `235.000` are treated as 235000
- format detail rows and totals with Paraguayan locale
- ensure subtotal updates while typing unit cost

## Testing
- `php -l paginas/referenciales/presupuestos_compra/agregar.php`
- `node --check vistas/presupuestos_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_689a220991f883259858f80904d36e4d