### PR TITLE
Elimina recepciones y bloquea ediciones diagnosticadas

### DIFF
--- a/controladores/recepcion.php
+++ b/controladores/recepcion.php
@@ -19,26 +19,28 @@ if (isset($_POST['actualizar'])) {
     $datos = json_decode($_POST['actualizar'], true);
     $db = new DB();
     $cn = $db->conectar();
-    $query = $cn->prepare(
-        "UPDATE recepcion SET fecha_recepcion = :fecha_recepcion, id_cliente = :id_cliente, nombre_cliente = :nombre_cliente, telefono = :telefono, direccion = :direccion, estado = :estado, observaciones = :observaciones WHERE id_recepcion = :id_recepcion"
-    );
-    $query->execute($datos);
-}
-
-// CERRAR RECEPCION
-if (isset($_POST['cerrar'])) {
-    $db = new DB();
-    $cn = $db->conectar();
-    $query = $cn->prepare("UPDATE recepcion SET estado = 'CERRADA' WHERE id_recepcion = :id");
-    $query->execute(['id' => $_POST['cerrar']]);
+    $check = $cn->prepare("SELECT estado FROM recepcion WHERE id_recepcion = :id");
+    $check->execute(['id' => $datos['id_recepcion']]);
+    $estado = $check->fetchColumn();
+    if ($estado !== 'DIAGNOSTICADO') {
+        $query = $cn->prepare(
+            "UPDATE recepcion SET fecha_recepcion = :fecha_recepcion, id_cliente = :id_cliente, nombre_cliente = :nombre_cliente, telefono = :telefono, direccion = :direccion, estado = :estado, observaciones = :observaciones WHERE id_recepcion = :id_recepcion"
+        );
+        $query->execute($datos);
+    }
 }
 
 // ELIMINAR RECEPCION
 if (isset($_POST['eliminar'])) {
     $db = new DB();
     $cn = $db->conectar();
-    $query = $cn->prepare("DELETE FROM recepcion WHERE id_recepcion = :id");
-    $query->execute(['id' => $_POST['eliminar']]);
+    $check = $cn->prepare("SELECT estado FROM recepcion WHERE id_recepcion = :id");
+    $check->execute(['id' => $_POST['eliminar']]);
+    $estado = $check->fetchColumn();
+    if ($estado !== 'DIAGNOSTICADO') {
+        $query = $cn->prepare("DELETE FROM recepcion WHERE id_recepcion = :id");
+        $query->execute(['id' => $_POST['eliminar']]);
+    }
 }
 
 // LISTAR RECEPCIONES

--- a/vistas/recepcion.js
+++ b/vistas/recepcion.js
@@ -214,6 +214,10 @@ function cargarTablaRecepcion(){
     let json = JSON.parse(datos);
     $("#recepcion_datos_tb").html('');
     json.map(function(it){
+      let acciones = `<button class="btn btn-info btn-sm imprimir-recepcion" title="Imprimir"><i class="bi bi-printer"></i></button>`;
+      if(it.estado !== "DIAGNOSTICADO"){
+        acciones += ` <button class="btn btn-warning btn-sm editar-recepcion" title="Editar"><i class="bi bi-pencil-square"></i></button> <button class="btn btn-danger btn-sm eliminar-recepcion" title="Eliminar"><i class="bi bi-trash"></i></button>`;
+      }
       $("#recepcion_datos_tb").append(`
         <tr>
           <td>${it.id_recepcion}</td>
@@ -222,11 +226,7 @@ function cargarTablaRecepcion(){
           <td>${it.telefono}</td>
           <td>${it.direccion}</td>
           <td>${badgeEstado(it.estado)}</td>
-          <td>
-            <button class="btn btn-info btn-sm imprimir-recepcion" title="Imprimir"><i class="bi bi-printer"></i></button>
-            <button class="btn btn-warning btn-sm editar-recepcion" title="Editar"><i class="bi bi-pencil-square"></i></button>
-            <button class="btn btn-danger btn-sm cerrar-recepcion" title="Cerrar"><i class="bi bi-x-circle"></i></button>
-          </td>
+          <td>${acciones}</td>
         </tr>`);
     });
   }
@@ -241,6 +241,10 @@ function buscarRecepcion(){
     let json = JSON.parse(datos);
     $("#recepcion_datos_tb").html('');
     json.map(function(it){
+      let acciones = `<button class="btn btn-info btn-sm imprimir-recepcion" title="Imprimir"><i class="bi bi-printer"></i></button>`;
+      if(it.estado !== "DIAGNOSTICADO"){
+        acciones += ` <button class="btn btn-warning btn-sm editar-recepcion" title="Editar"><i class="bi bi-pencil-square"></i></button> <button class="btn btn-danger btn-sm eliminar-recepcion" title="Eliminar"><i class="bi bi-trash"></i></button>`;
+      }
       $("#recepcion_datos_tb").append(`
         <tr>
           <td>${it.id_recepcion}</td>
@@ -249,11 +253,7 @@ function buscarRecepcion(){
           <td>${it.telefono}</td>
           <td>${it.direccion}</td>
           <td>${badgeEstado(it.estado)}</td>
-          <td>
-            <button class="btn btn-info btn-sm imprimir-recepcion" title="Imprimir"><i class="bi bi-printer"></i></button>
-            <button class="btn btn-warning btn-sm editar-recepcion" title="Editar"><i class="bi bi-pencil-square"></i></button>
-            <button class="btn btn-danger btn-sm cerrar-recepcion" title="Cerrar"><i class="bi bi-x-circle"></i></button>
-          </td>
+          <td>${acciones}</td>
         </tr>`);
     });
   }
@@ -411,22 +411,22 @@ $(document).on("click",".imprimir-recepcion",function(){
   imprimirRecepcion(id);
 });
 
-$(document).on("click",".cerrar-recepcion",function(){
+$(document).on("click",".eliminar-recepcion",function(){
   let id=$(this).closest("tr").find("td:eq(0)").text();
   Swal.fire({
-    title:"¿Cerrar recepción?",
-    text:"Esta acción marcará la recepción como cerrada.",
+    title:"¿Eliminar recepción?",
+    text:"Esta acción eliminará la recepción.",
     icon:"warning",
     showCancelButton:true,
-    confirmButtonText:"Sí, cerrar",
+    confirmButtonText:"Sí, eliminar",
     cancelButtonText:"Cancelar",
     confirmButtonColor:"#dc3545",
     cancelButtonColor:"#6c757d",
     reverseButtons:true
   }).then((result)=>{
     if(result.isConfirmed){
-      ejecutarAjax("controladores/recepcion.php","cerrar="+id);
-      mensaje_confirmacion("Recepción cerrada");
+      ejecutarAjax("controladores/recepcion.php","eliminar="+id);
+      mensaje_confirmacion("Recepción eliminada");
       cargarTablaRecepcion();
     }
   });


### PR DESCRIPTION
## Summary
- Reemplaza el cierre de recepciones por su eliminación definitiva desde la interfaz
- Oculta botones de edición y eliminación cuando la recepción está diagnosticada y valida en el servidor

## Testing
- `php -l controladores/recepcion.php`
- `node --check vistas/recepcion.js`


------
https://chatgpt.com/codex/tasks/task_e_689b76f990248325887b170d7df193fa