### PR TITLE
Add state and date filters to purchase orders

### DIFF
--- a/paginas/referenciales/orden_compra/listar.php
+++ b/paginas/referenciales/orden_compra/listar.php
@@ -12,13 +12,35 @@
     <!-- Card principal -->
     <div class="card shadow rounded-4 border-0">
         <div class="card-body">
-            <!-- Buscador -->
+            <!-- Buscador y filtros -->
             <div class="row g-3 align-items-end mb-3">
-                <div class="col-md-8">
+                <div class="col-md-6">
                     <label for="b_orden" class="form-label fw-semibold">Buscar orden</label>
-                    <input type="text" id="b_orden" class="form-control form-control-lg" placeholder="Buscar por proveedor...">
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="bi bi-search"></i></span>
+                        <input type="text" id="b_orden" class="form-control form-control-lg" placeholder="Buscar por proveedor...">
+                        <button class="btn btn-outline-secondary" type="button" id="limpiar_busqueda_btn"><i class="bi bi-x-lg"></i></button>
+                    </div>
                 </div>
-                
+
+                <div class="col-md-3">
+                    <label for="estado_filtro" class="form-label fw-semibold">Estado</label>
+                    <select id="estado_filtro" class="form-select">
+                        <option value="">Todos</option>
+                        <option value="EMITIDO">Emitido</option>
+                        <option value="APROBADO">Aprobado</option>
+                        <option value="ANULADO">Anulado</option>
+                    </select>
+                </div>
+
+                <div class="col-md-3">
+                    <label class="form-label fw-semibold">Rango de fechas</label>
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="bi bi-calendar3"></i></span>
+                        <input type="date" id="f_desde" class="form-control" placeholder="Desde">
+                        <input type="date" id="f_hasta" class="form-control" placeholder="Hasta">
+                    </div>
+                </div>
             </div>
 
             <!-- Tabla -->

--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -482,13 +482,7 @@ function limpiarOrden(){
 // Listado / Búsqueda
 // -----------------------------
 function cargarTablaOrden(){
-  console.log("Entró en cargarTablaOrden()");
-  let datos = ejecutarAjax("controladores/orden_compra.php","leer=1");
-  if(datos !== "0"){
-    renderTablaOrden(JSON.parse(datos));
-  }else{
-    $("#orden_datos_tb").html("");
-  }
+  buscarOrden();
 }
 
 function renderTablaOrden(arr){
@@ -570,16 +564,34 @@ $(document).on('click','.imprimir-orden',function(){
 });
 
 function buscarOrden(){
-  let datos = ejecutarAjax("controladores/orden_compra.php","leer_descripcion="+$("#b_orden").val());
+  let b = $("#b_orden").val();
+  let estado = $("#estado_filtro").val();
+  let desde = $("#f_desde").val();
+  let hasta = $("#f_hasta").val();
+
+  let datos = ejecutarAjax(
+    "controladores/orden_compra.php",
+    "leer_descripcion="+encodeURIComponent(b)+"&estado="+estado+"&desde="+desde+"&hasta="+hasta
+  );
   if(datos !== "0"){
     renderTablaOrden(JSON.parse(datos));
   }else{
-    $("#orden_datos_tb").html("");
+    $("#orden_datos_tb").html("NO HAY REGISTROS");
   }
 }
 window.buscarOrden = buscarOrden;
 
 $(document).on('keyup','#b_orden',function(){
+  buscarOrden();
+});
+$(document).on('change','#estado_filtro, #f_desde, #f_hasta',function(){
+  buscarOrden();
+});
+$(document).on('click','#limpiar_busqueda_btn',function(){
+  $("#b_orden").val('');
+  $("#estado_filtro").val('');
+  $("#f_desde").val('');
+  $("#f_hasta").val('');
   buscarOrden();
 });
 


### PR DESCRIPTION
## Summary
- add status and date range filters to purchase order listing
- wire up UI controls and AJAX to apply the filters

## Testing
- `php -l controladores/orden_compra.php`
- `php -l paginas/referenciales/orden_compra/listar.php`
- `node --check vistas/orden_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_689b95fb8da4832580e266b4d2540057