### PR TITLE
Agregar CRUD de conductores

### DIFF
--- a/controladores/conductor.php
+++ b/controladores/conductor.php
@@ -1,0 +1,79 @@
+<?php
+require_once '../conexion/db.php';
+
+$base_datos = new DB();
+$db = $base_datos->conectar();
+
+if (isset($_POST['guardar'])) {
+    $datos = array_map('trim', json_decode($_POST['guardar'], true));
+
+    // Verificar si la cédula ya existe
+    $query = $db->prepare("SELECT COUNT(*) FROM conductor WHERE cedula = :cedula");
+    $query->execute(['cedula' => $datos['cedula']]);
+    if ($query->fetchColumn() > 0) {
+        echo 'duplicado';
+        return;
+    }
+
+    $query = $db->prepare(
+        "INSERT INTO conductor (nombre, cedula, telefono, licencia_conduccion, estado) " .
+        "VALUES (:nombre, :cedula, :telefono, :licencia_conduccion, :estado)"
+    );
+    $query->execute($datos);
+    echo 'ok';
+}
+
+if (isset($_POST['actualizar'])) {
+    $datos = array_map('trim', json_decode($_POST['actualizar'], true));
+
+    // Verificar si la cédula ya existe para otro conductor
+    $query = $db->prepare(
+        "SELECT COUNT(*) FROM conductor WHERE cedula = :cedula AND id_conductor <> :id_conductor"
+    );
+    $query->execute([
+        'cedula' => $datos['cedula'],
+        'id_conductor' => $datos['id_conductor']
+    ]);
+    if ($query->fetchColumn() > 0) {
+        echo 'duplicado';
+        return;
+    }
+
+    $query = $db->prepare(
+        "UPDATE conductor SET nombre = :nombre, cedula = :cedula, telefono = :telefono, " .
+        "licencia_conduccion = :licencia_conduccion, estado = :estado WHERE id_conductor = :id_conductor"
+    );
+    $query->execute($datos);
+    echo 'ok';
+}
+
+if (isset($_POST['eliminar'])) {
+    $query = $db->prepare("DELETE FROM conductor WHERE id_conductor = :id");
+    $query->execute(['id' => $_POST['eliminar']]);
+}
+
+if (isset($_POST['leer'])) {
+    $query = $db->prepare(
+        "SELECT id_conductor, nombre, cedula, telefono, licencia_conduccion, estado FROM conductor ORDER BY id_conductor DESC"
+    );
+    $query->execute();
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+if (isset($_POST['leer_descripcion'])) {
+    $filtro = '%' . $_POST['leer_descripcion'] . '%';
+    $query = $db->prepare(
+        "SELECT id_conductor, nombre, cedula, telefono, licencia_conduccion, estado " .
+        "FROM conductor WHERE CONCAT(id_conductor, nombre, cedula, telefono, licencia_conduccion, estado) LIKE :filtro"
+    );
+    $query->execute(['filtro' => $filtro]);
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
+if (isset($_POST['leer_id'])) {
+    $query = $db->prepare(
+        "SELECT id_conductor, nombre, cedula, telefono, licencia_conduccion, estado FROM conductor WHERE id_conductor = :id"
+    );
+    $query->execute(['id' => $_POST['leer_id']]);
+    echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
+}

--- a/menu.php
+++ b/menu.php
@@ -326,6 +326,12 @@
     <p>Clientes</p>
   </a>
 </li>
+  <li class="nav-item">
+    <a href="#" class="nav-link" onclick="mostrarListarConductor(); return false;">
+      <i class="nav-icon bi bi-person-vcard"></i>
+      <p>Conductores</p>
+    </a>
+  </li>
                   <li class="nav-item">
                       <a href="#" class="nav-link" 
                          onclick="mostrarListarDepartamento(); return false;">
@@ -772,6 +778,7 @@
     <script src="vistas/resenas.js"></script>
     <script src="vistas/proveedor.js"></script>
     <script src="vistas/cliente.js"></script>
+    <script src="vistas/conductor.js"></script>
     <script src="vistas/productos.js"></script>
     <script src="vistas/remision.js"></script>
     <script src="vistas/recepcion.js"></script>

--- a/paginas/referenciales/conductor/agregar.php
+++ b/paginas/referenciales/conductor/agregar.php
@@ -1,0 +1,43 @@
+<div class="container mt-4">
+  <input type="hidden" id="id_conductor" value="0">
+  <div class="card shadow-lg rounded-4 border-0">
+    <div class="card-header bg-success text-white rounded-top-4">
+      <h4 class="mb-0"><i class="bi bi-person-vcard me-2"></i> Agregar / Editar Conductor</h4>
+    </div>
+    <div class="card-body">
+      <div class="row g-4">
+        <div class="col-md-6">
+          <label for="nombre_txt" class="form-label fw-semibold">Nombre</label>
+          <input type="text" id="nombre_txt" class="form-control" placeholder="Ej. Juan Pérez">
+        </div>
+        <div class="col-md-6">
+          <label for="cedula_txt" class="form-label fw-semibold">Cédula</label>
+          <input type="text" id="cedula_txt" class="form-control" placeholder="Ej. 1234567">
+        </div>
+        <div class="col-md-6">
+          <label for="telefono_txt" class="form-label fw-semibold">Teléfono</label>
+          <input type="text" id="telefono_txt" class="form-control" placeholder="Ej. 0981 123456">
+        </div>
+        <div class="col-md-6">
+          <label for="licencia_txt" class="form-label fw-semibold">Licencia de Conducción</label>
+          <input type="text" id="licencia_txt" class="form-control" placeholder="Ej. B">
+        </div>
+        <div class="col-md-6">
+          <label for="estado_lst" class="form-label fw-semibold">Estado</label>
+          <select id="estado_lst" class="form-select">
+            <option value="ACTIVO">ACTIVO</option>
+            <option value="INACTIVO">INACTIVO</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="card-footer text-end bg-light rounded-bottom-4">
+      <button class="btn btn-success me-2" onclick="guardarConductor(); return false;">
+        <i class="bi bi-save me-1"></i> Guardar
+      </button>
+      <button class="btn btn-danger" onclick="mostrarListarConductor(); return false;">
+        <i class="bi bi-x-circle me-1"></i> Cancelar
+      </button>
+    </div>
+  </div>
+</div>

--- a/paginas/referenciales/conductor/listar.php
+++ b/paginas/referenciales/conductor/listar.php
@@ -1,0 +1,48 @@
+<div class="container mt-4">
+  <div class="shadow-lg rounded-4 p-4 bg-white bg-opacity-75 position-relative">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h3 class="text-primary fw-bold mb-0">
+        <i class="bi bi-person-vcard me-2"></i> Conductores
+      </h3>
+      <div class="d-flex gap-2">
+        <button class="btn btn-outline-primary shadow-sm d-flex align-items-center" onclick="imprimirConductores(); return false;">
+          <i class="bi bi-printer-fill me-2"></i> Imprimir
+        </button>
+        <button class="btn btn-success shadow-sm d-flex align-items-center" onclick="mostrarAgregarConductor(); return false;">
+          <i class="bi bi-plus-circle me-2"></i> Nuevo Conductor
+        </button>
+      </div>
+    </div>
+
+    <div class="card border-0 bg-light bg-opacity-75 rounded-4 shadow-sm mb-4">
+      <div class="card-body">
+        <div class="row g-3 align-items-end">
+          <div class="col-md-12">
+            <label for="b_conductor" class="form-label fw-semibold">
+              <i class="bi bi-search me-2"></i> Buscar conductor
+            </label>
+            <input type="text" id="b_conductor" class="form-control form-control-lg" placeholder="Buscar por nombre, cédula o teléfono...">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table table-striped table-hover align-middle text-center border rounded-4 overflow-hidden shadow-sm">
+        <thead class="table-primary">
+          <tr>
+            <th>#</th>
+            <th>Nombre</th>
+            <th>Cédula</th>
+            <th>Teléfono</th>
+            <th>Licencia</th>
+            <th>Estado</th>
+            <th>Operaciones</th>
+          </tr>
+        </thead>
+        <tbody id="datos_tb">
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/paginas/referenciales/conductor/print.php
+++ b/paginas/referenciales/conductor/print.php
@@ -1,0 +1,65 @@
+<?php
+require_once '../conexion/db.php';
+
+$base_datos = new DB();
+$db = $base_datos->conectar();
+
+$query = $db->prepare("SELECT id_conductor, nombre, cedula, telefono, licencia_conduccion, estado FROM conductor");
+$query->execute();
+$conductores = $query->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Reporte de Conductores</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+    <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h3 class="mb-0">🚗 Reporte de Conductores</h3>
+            <button class="btn btn-outline-primary" onclick="window.print()">🖨️ Imprimir</button>
+        </div>
+        <table class="table table-bordered table-hover table-striped">
+            <thead class="table-dark">
+                <tr>
+                    <th>ID</th>
+                    <th>Nombre</th>
+                    <th>Cédula</th>
+                    <th>Teléfono</th>
+                    <th>Licencia</th>
+                    <th>Estado</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($conductores as $c): ?>
+                <tr>
+                    <td><?= htmlspecialchars($c['id_conductor']) ?></td>
+                    <td><?= htmlspecialchars($c['nombre']) ?></td>
+                    <td><?= htmlspecialchars($c['cedula']) ?></td>
+                    <td><?= htmlspecialchars($c['telefono']) ?></td>
+                    <td><?= htmlspecialchars($c['licencia_conduccion']) ?></td>
+                    <td>
+                        <?php
+                            $est = strtoupper($c['estado']);
+                            $class = 'secondary';
+                            if ($est === 'ACTIVO' || $est === 'APROBADO') { $class = 'success'; }
+                            elseif ($est === 'PENDIENTE') { $class = 'warning text-dark'; }
+                            elseif ($est === 'INACTIVO' || $est === 'ANULADO') { $class = 'danger'; }
+                        ?>
+                        <span class="badge bg-<?= $class ?>"><?= htmlspecialchars($c['estado']) ?></span>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+                <?php if (count($conductores) === 0): ?>
+                <tr>
+                    <td colspan="6" class="text-center text-muted">No se encontraron conductores.</td>
+                </tr>
+                <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/utcdp1.sql
+++ b/utcdp1.sql
@@ -222,6 +222,19 @@ CREATE TABLE `cliente` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `conductor`
+--
+CREATE TABLE `conductor` (
+  `id_conductor` int(11) NOT NULL,
+  `nombre` varchar(100) NOT NULL,
+  `cedula` varchar(20) NOT NULL,
+  `telefono` varchar(20) NOT NULL,
+  `licencia_conduccion` varchar(50) NOT NULL,
+  `estado` varchar(20) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
 
 --
 -- Estructura de tabla para la tabla `productos`
@@ -453,6 +466,12 @@ ALTER TABLE `cliente`
   ADD PRIMARY KEY (`id_cliente`);
 
 --
+-- Indices de la tabla `conductor`
+--
+ALTER TABLE `conductor`
+  ADD PRIMARY KEY (`id_conductor`);
+
+--
 -- Indices de la tabla `resenas`
 --
 ALTER TABLE `resenas`
@@ -536,6 +555,10 @@ ALTER TABLE `proveedor`
 --
 ALTER TABLE `cliente`
   MODIFY `id_cliente` int(11) NOT NULL AUTO_INCREMENT;
+
+-- AUTO_INCREMENT de la tabla `conductor`
+ALTER TABLE `conductor`
+  MODIFY `id_conductor` int(11) NOT NULL AUTO_INCREMENT;
 
 -- AUTO_INCREMENT de la tabla `presupuestos_compra`
 ALTER TABLE `presupuestos_compra`

--- a/vistas/conductor.js
+++ b/vistas/conductor.js
@@ -1,0 +1,186 @@
+function mostrarListarConductor(){
+    let contenido = dameContenido("paginas/referenciales/conductor/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaConductor();
+}
+
+function mostrarAgregarConductor(callback = null){
+    let contenido = dameContenido("paginas/referenciales/conductor/agregar.php");
+    $("#contenido-principal").html(contenido);
+    if(callback){
+        setTimeout(callback,100);
+    }
+}
+
+function imprimirConductores() {
+    let datos = ejecutarAjax("controladores/conductor.php", "leer=1");
+
+    if (!datos || datos === "0") {
+        alert("No hay conductores para imprimir.");
+        return;
+    }
+
+    let json = JSON.parse(datos);
+    let filas = "";
+    json.forEach(c => {
+        filas += `<tr><td>${c.id_conductor}</td><td>${c.nombre}</td><td>${c.cedula}</td><td>${c.telefono}</td><td>${c.licencia_conduccion}</td><td>${c.estado}</td></tr>`;
+    });
+
+    let ventana = window.open('', '', 'width=900,height=700');
+    ventana.document.write(`
+        <html>
+        <head>
+            <title>Reporte de Conductores</title>
+            <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+        </head>
+        <body class="p-4">
+            <h3 class="mb-4">🚗 Reporte de Conductores</h3>
+            <table class="table table-bordered">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Nombre</th>
+                        <th>Cédula</th>
+                        <th>Teléfono</th>
+                        <th>Licencia</th>
+                        <th>Estado</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${filas}
+                </tbody>
+            </table>
+        </body>
+        </html>
+    `);
+    ventana.document.close();
+    ventana.focus();
+    ventana.print();
+}
+
+function guardarConductor(){
+    if($("#nombre_txt").val().trim().length===0){
+        mensaje_dialogo_info_ERROR("Debes ingresar el nombre", "ATENCION");
+        return;
+    }
+    if($("#cedula_txt").val().trim().length===0){
+        mensaje_dialogo_info_ERROR("Debes ingresar la cédula", "ATENCION");
+        return;
+    }
+    if($("#telefono_txt").val().trim().length===0){
+        mensaje_dialogo_info_ERROR("Debes ingresar el teléfono", "ATENCION");
+        return;
+    }
+    if($("#licencia_txt").val().trim().length===0){
+        mensaje_dialogo_info_ERROR("Debes ingresar la licencia", "ATENCION");
+        return;
+    }
+
+    let datos={
+        nombre: $("#nombre_txt").val().trim(),
+        cedula: $("#cedula_txt").val().trim(),
+        telefono: $("#telefono_txt").val().trim(),
+        licencia_conduccion: $("#licencia_txt").val().trim(),
+        estado: $("#estado_lst").val()
+    };
+
+    if($("#id_conductor").val()==="0"){
+        let res = ejecutarAjax("controladores/conductor.php","guardar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("La cédula ya está registrada", "ATENCION");
+            return;
+        }
+        mensaje_confirmacion("Guardado correctamente");
+        mostrarListarConductor();
+        limpiarConductor();
+    }else{
+        datos = {...datos, id_conductor: $("#id_conductor").val()};
+        let res = ejecutarAjax("controladores/conductor.php","actualizar="+JSON.stringify(datos));
+        if(res === "duplicado"){
+            mensaje_dialogo_info_ERROR("La cédula ya está registrada", "ATENCION");
+            return;
+        }
+        mensaje_confirmacion("Actualizado correctamente");
+        mostrarListarConductor();
+        limpiarConductor();
+    }
+}
+
+function cargarTablaConductor(){
+    let datos = ejecutarAjax("controladores/conductor.php","leer=1");
+    if(datos === "0"){
+        $("#datos_tb").html("NO HAY REGISTROS");
+    }else{
+        let json = JSON.parse(datos);
+        $("#datos_tb").html("");
+        json.map(function(it){
+            $("#datos_tb").append(`<tr>
+                <td>${it.id_conductor}</td>
+                <td>${it.nombre}</td>
+                <td>${it.cedula}</td>
+                <td>${it.telefono}</td>
+                <td>${it.licencia_conduccion}</td>
+                <td>${badgeEstado(it.estado)}</td>
+                <td>
+                    <button class="btn btn-warning editar-conductor"><i class="bi bi-pencil-square"></i></button>
+                    <button class="btn btn-danger eliminar-conductor"><i class="bi bi-trash"></i></button>
+                </td>
+            </tr>`);
+        });
+    }
+}
+
+$(document).on("click", ".editar-conductor", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    let conductor = ejecutarAjax("controladores/conductor.php","leer_id="+id);
+    let json = JSON.parse(conductor);
+    mostrarAgregarConductor(function(){
+        $("#nombre_txt").val(json.nombre);
+        $("#cedula_txt").val(json.cedula);
+        $("#telefono_txt").val(json.telefono);
+        $("#licencia_txt").val(json.licencia_conduccion);
+        $("#estado_lst").val(json.estado);
+        $("#id_conductor").val(json.id_conductor);
+    });
+});
+
+$(document).on("click", ".eliminar-conductor", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    if(confirm("¿Eliminar conductor?")){
+        ejecutarAjax("controladores/conductor.php","eliminar="+id);
+        cargarTablaConductor();
+    }
+});
+
+$(document).on("keyup", "#b_conductor", function(){
+    let datos = ejecutarAjax("controladores/conductor.php","leer_descripcion="+$("#b_conductor").val());
+    if(datos === "0"){
+        $("#datos_tb").html("NO HAY REGISTROS");
+    }else{
+        let json = JSON.parse(datos);
+        $("#datos_tb").html("");
+        json.map(function(it){
+            $("#datos_tb").append(`<tr>
+                <td>${it.id_conductor}</td>
+                <td>${it.nombre}</td>
+                <td>${it.cedula}</td>
+                <td>${it.telefono}</td>
+                <td>${it.licencia_conduccion}</td>
+                <td>${badgeEstado(it.estado)}</td>
+                <td>
+                    <button class="btn btn-warning editar-conductor"><i class="bi bi-pencil-square"></i></button>
+                    <button class="btn btn-danger eliminar-conductor"><i class="bi bi-trash"></i></button>
+                </td>
+            </tr>`);
+        });
+    }
+});
+
+function limpiarConductor(){
+    $("#nombre_txt").val("");
+    $("#cedula_txt").val("");
+    $("#telefono_txt").val("");
+    $("#licencia_txt").val("");
+    $("#estado_lst").val("ACTIVO");
+    $("#id_conductor").val("0");
+}


### PR DESCRIPTION
## Summary
- Añade controlador PHP para gestionar conductores.
- Crea vistas y scripts para listar, crear, editar e imprimir conductores.
- Actualiza menú principal y script de inicialización.
- Incluye tabla `conductor` en el archivo SQL.

## Testing
- `php -l controladores/conductor.php`
- `php -l paginas/referenciales/conductor/agregar.php`
- `php -l paginas/referenciales/conductor/listar.php`
- `php -l paginas/referenciales/conductor/print.php`
- `php -l menu.php`


------
https://chatgpt.com/codex/tasks/task_e_689ca50937b0832593a879c3abf01d52