### PR TITLE
Agregar campo de validez a presupuestos

### DIFF
--- a/controladores/presupuestos_compra.php
+++ b/controladores/presupuestos_compra.php
@@ -7,7 +7,7 @@ if (isset($_POST['guardar'])) {
     $db = new DB();
     $cn = $db->conectar();
     $query = $cn->prepare(
-        "INSERT INTO presupuestos_compra (fecha, id_proveedor, total_estimado, estado) VALUES (:fecha, :id_proveedor, :total_estimado, 'PENDIENTE')"
+        "INSERT INTO presupuestos_compra (fecha, id_proveedor, total_estimado, validez, estado) VALUES (:fecha, :id_proveedor, :total_estimado, :validez, 'PENDIENTE')"
     );
     $query->execute($datos);
     echo $cn->lastInsertId();
@@ -18,7 +18,7 @@ if (isset($_POST['actualizar'])) {
     $datos = json_decode($_POST['actualizar'], true);
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "UPDATE presupuestos_compra SET fecha = :fecha, id_proveedor = :id_proveedor, total_estimado = :total_estimado WHERE id_presupuesto = :id_presupuesto"
+        "UPDATE presupuestos_compra SET fecha = :fecha, id_proveedor = :id_proveedor, total_estimado = :total_estimado, validez = :validez WHERE id_presupuesto = :id_presupuesto"
     );
     $query->execute($datos);
 }
@@ -41,7 +41,7 @@ if (isset($_POST['anular'])) {
 if (isset($_POST['leer'])) {
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor ORDER BY p.id_presupuesto DESC"
+        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.validez, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor ORDER BY p.id_presupuesto DESC"
     );
     $query->execute();
     if ($query->rowCount()) {
@@ -55,7 +55,7 @@ if (isset($_POST['leer'])) {
 if (isset($_POST['leerPendiente'])) {
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE p.estado = 'PENDIENTE' ORDER BY p.id_presupuesto DESC"
+        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.validez, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE p.estado = 'PENDIENTE' ORDER BY p.id_presupuesto DESC"
     );
     $query->execute();
     if ($query->rowCount()) {
@@ -69,7 +69,7 @@ if (isset($_POST['leerPendiente'])) {
 if (isset($_POST['leer_id'])) {
     $db = new DB();
     $query = $db->conectar()->prepare(
-        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado " .
+        "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.validez, p.estado " .
         "FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor " .
         "WHERE p.id_presupuesto = :id"
     );
@@ -86,7 +86,7 @@ if (isset($_POST['leer_descripcion'])) {
     $f = '%' . $_POST['leer_descripcion'] . '%';
     $estado = $_POST['estado'] ?? '';
     $db = new DB();
-    $sql = "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE CONCAT(p.id_presupuesto, pr.razon_social) LIKE :filtro";
+    $sql = "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.validez, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE CONCAT(p.id_presupuesto, pr.razon_social) LIKE :filtro";
     if ($estado !== '') {
         $sql .= " AND p.estado = :estado";
     }

--- a/paginas/referenciales/presupuestos_compra/agregar.php
+++ b/paginas/referenciales/presupuestos_compra/agregar.php
@@ -33,11 +33,20 @@
         </div>
 
         <!-- Fecha -->
-        <div class="col-md-6">
+        <div class="col-md-3">
           <label class="form-label fw-semibold" for="fecha_txt">Fecha</label>
           <div class="input-group">
             <span class="input-group-text"><i class="bi bi-calendar3"></i></span>
             <input type="date" id="fecha_txt" class="form-control" placeholder="Fecha">
+          </div>
+        </div>
+
+        <!-- Validez en días -->
+        <div class="col-md-3">
+          <label class="form-label fw-semibold" for="validez_txt">Validez (días)</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="bi bi-hourglass-split"></i></span>
+            <input type="number" id="validez_txt" class="form-control text-end" placeholder="0" min="0">
           </div>
         </div>
       </div>
@@ -211,11 +220,20 @@
         </div>
 
         <!-- Fecha -->
-        <div class="col-md-6">
+        <div class="col-md-3">
           <label class="form-label fw-semibold" for="fecha_txt">Fecha</label>
           <div class="input-group">
             <span class="input-group-text"><i class="bi bi-calendar3"></i></span>
             <input type="date" id="fecha_txt" class="form-control" placeholder="Fecha">
+          </div>
+        </div>
+
+        <!-- Validez en días -->
+        <div class="col-md-3">
+          <label class="form-label fw-semibold" for="validez_txt">Validez (días)</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="bi bi-hourglass-split"></i></span>
+            <input type="number" id="validez_txt" class="form-control text-end" placeholder="0" min="0">
           </div>
         </div>
       </div>

--- a/paginas/referenciales/presupuestos_compra/listar.php
+++ b/paginas/referenciales/presupuestos_compra/listar.php
@@ -56,11 +56,12 @@
           <thead class="table-primary position-sticky top-0" style="z-index:1;">
             <tr>
               <th style="width: 6%">#</th>
-              <th style="width: 30%">Proveedor</th>
-              <th style="width: 16%">Fecha</th>
-              <th class="text-end" style="width: 16%">Total Estimado</th>
+              <th style="width: 26%">Proveedor</th>
+              <th style="width: 14%">Fecha</th>
+              <th style="width: 12%">Validez (días)</th>
+              <th class="text-end" style="width: 14%">Total Estimado</th>
               <th style="width: 14%">Estado</th>
-              <th style="width: 18%">Operaciones</th>
+              <th style="width: 14%">Operaciones</th>
             </tr>
           </thead>
           <tbody id="datos_tb">

--- a/utcdp1.sql
+++ b/utcdp1.sql
@@ -254,6 +254,7 @@ CREATE TABLE `presupuestos_compra` (
   `fecha` date NOT NULL,
   `id_proveedor` int(11) NOT NULL,
   `total_estimado` decimal(10,2) NOT NULL,
+  `validez` int(11) NOT NULL,
   `estado` varchar(20) NOT NULL DEFAULT 'REALIZADO'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -285,6 +285,11 @@ function guardarPresupuesto(){
     mensaje_dialogo_info_ERROR("Debe ingresar la fecha", "ERROR");
     return;
   }
+  const validez = parseInt($("#validez_txt").val(),10);
+  if(isNaN(validez) || validez <= 0){
+    mensaje_dialogo_info_ERROR("Debe ingresar la validez en días", "ERROR");
+    return;
+  }
   if(detalles.length === 0){
     mensaje_dialogo_info_ERROR("Debe agregar al menos un producto", "ERROR");
     return;
@@ -298,7 +303,8 @@ function guardarPresupuesto(){
   let datos = {
     id_proveedor: idProv,
     fecha: $("#fecha_txt").val(),
-    total_estimado: totalNum
+    total_estimado: totalNum,
+    validez: validez
   };
 
   if($("#id_presupuesto").val() === "0"){
@@ -362,6 +368,7 @@ function cargarTablaPresupuesto(){
           <td>${it.id_presupuesto}</td>
           <td class="text-start">${it.proveedor}</td>
           <td>${it.fecha}</td>
+          <td>${it.validez}</td>
           <td class="text-end">${fmt0(toNumberPY(it.total_estimado))}</td>
           <td>${badgeEstado(it.estado)}</td>
           <td>
@@ -390,6 +397,7 @@ $(document).on("click",".editar-presupuesto",function(){
   $("#id_presupuesto").val(json.id_presupuesto);
   $("#id_proveedor_lst").val(json.id_proveedor);
   $("#fecha_txt").val(json.fecha);
+  $("#validez_txt").val(json.validez);
   $("#total_txt").val(fmt0(toNumberPY(json.total_estimado)));
 
   let det = ejecutarAjax("controladores/detalle_presupuesto.php","leer=1&id_presupuesto="+id);
@@ -464,6 +472,7 @@ function buscarPresupuesto(){
           <td>${it.id_presupuesto}</td>
           <td class="text-start">${it.proveedor}</td>
           <td>${it.fecha}</td>
+          <td>${it.validez}</td>
           <td class="text-end">${fmt0(toNumberPY(it.total_estimado))}</td>
           <td>${badgeEstado(it.estado)}</td>
           <td>
@@ -546,6 +555,7 @@ function imprimirPresupuesto(id){
           Proveedor: <strong>${presupuesto.proveedor || presupuesto.id_proveedor}</strong>
           &nbsp;·&nbsp; Estado: <span class="badge ${estadoBadge}">${presupuesto.estado || "PENDIENTE"}</span>
           &nbsp;·&nbsp; Fecha: <strong>${formatearFechaDMA(presupuesto.fecha)}</strong>
+          &nbsp;·&nbsp; Validez: <strong>${presupuesto.validez} días</strong>
         </div>
       </div>
     </div>
@@ -601,6 +611,7 @@ function limpiarPresupuesto(){
   $("#id_detalle").val("0");
   $("#id_proveedor_lst").val("");
   $("#fecha_txt").val("");
+  $("#validez_txt").val("");
   $("#total_txt").val("");
   $("#id_producto_lst").val("");
   $("#cantidad_txt").val("");


### PR DESCRIPTION
## Summary
- permitir indicar la validez en días de cada presupuesto
- mostrar la validez en los listados, edición e impresión de presupuestos

## Testing
- `php -l controladores/presupuestos_compra.php`
- `php -l paginas/referenciales/presupuestos_compra/agregar.php`
- `php -l paginas/referenciales/presupuestos_compra/listar.php`
- `node --check vistas/presupuestos_compra.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689ca5bd3284832590b9323621cc5f72