### PR TITLE
Enable date range filter and budget count badge

### DIFF
--- a/controladores/presupuestos_compra.php
+++ b/controladores/presupuestos_compra.php
@@ -85,16 +85,31 @@ if (isset($_POST['leer_id'])) {
 if (isset($_POST['leer_descripcion'])) {
     $f = '%' . $_POST['leer_descripcion'] . '%';
     $estado = $_POST['estado'] ?? '';
+    $f_desde = $_POST['f_desde'] ?? '';
+    $f_hasta = $_POST['f_hasta'] ?? '';
     $db = new DB();
     $sql = "SELECT p.id_presupuesto, p.fecha, p.id_proveedor, pr.razon_social AS proveedor, p.total_estimado, p.validez, p.estado FROM presupuestos_compra p LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor WHERE CONCAT(p.id_presupuesto, pr.razon_social) LIKE :filtro";
     if ($estado !== '') {
         $sql .= " AND p.estado = :estado";
+    }
+    if ($f_desde !== '' && $f_hasta !== '') {
+        $sql .= " AND p.fecha BETWEEN :desde AND :hasta";
+    } elseif ($f_desde !== '') {
+        $sql .= " AND p.fecha >= :desde";
+    } elseif ($f_hasta !== '') {
+        $sql .= " AND p.fecha <= :hasta";
     }
     $sql .= " ORDER BY p.id_presupuesto DESC";
     $query = $db->conectar()->prepare($sql);
     $params = ['filtro' => $f];
     if ($estado !== '') {
         $params['estado'] = $estado;
+    }
+    if ($f_desde !== '') {
+        $params['desde'] = $f_desde;
+    }
+    if ($f_hasta !== '') {
+        $params['hasta'] = $f_hasta;
     }
     $query->execute($params);
     if ($query->rowCount()) {

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -354,37 +354,43 @@ function guardarPresupuesto(){
 /* =========================
    Listado / búsqueda
    ========================= */
-function cargarTablaPresupuesto(){
-  let datos = ejecutarAjax("controladores/presupuestos_compra.php","leer=1");
+function renderTablaPresupuestos(datos){
   if(datos === "0"){
     $("#datos_tb").html("NO HAY REGISTROS");
-  }else{
-    $("#datos_tb").html("");
-    let json = JSON.parse(datos);
-    json.map(function(it){
-      const disabled = it.estado === 'ANULADO' ? 'disabled' : '';
-      $("#datos_tb").append(`
-        <tr>
-          <td>${it.id_presupuesto}</td>
-          <td class="text-start">${it.proveedor}</td>
-          <td>${it.fecha}</td>
-          <td>${it.validez}</td>
-          <td class="text-end">${fmt0(toNumberPY(it.total_estimado))}</td>
-          <td>${badgeEstado(it.estado)}</td>
-          <td>
-            <button class="btn btn-info ver-detalle" title="Imprimir">
-              <i class="bi bi-printer"></i>
-            </button>
-            <button class="btn btn-warning editar-presupuesto" ${disabled} title="Editar">
-              <i class="bi bi-pencil-square"></i>
-            </button>
-            <button class="btn btn-danger anular-presupuesto" ${disabled} title="Anular">
-              <i class="bi bi-x-circle"></i>
-            </button>
-          </td>
-        </tr>`);
-    });
+    $("#presupuesto_count").text("0");
+    return;
   }
+  const json = JSON.parse(datos);
+  $("#presupuesto_count").text(json.length);
+  $("#datos_tb").html("");
+  json.map(function(it){
+    const disabled = it.estado === 'ANULADO' ? 'disabled' : '';
+    $("#datos_tb").append(`
+      <tr>
+        <td>${it.id_presupuesto}</td>
+        <td class="text-start">${it.proveedor}</td>
+        <td>${it.fecha}</td>
+        <td>${it.validez}</td>
+        <td class="text-end">${fmt0(toNumberPY(it.total_estimado))}</td>
+        <td>${badgeEstado(it.estado)}</td>
+        <td>
+          <button class="btn btn-info ver-detalle" title="Imprimir">
+            <i class="bi bi-printer"></i>
+          </button>
+          <button class="btn btn-warning editar-presupuesto" ${disabled} title="Editar">
+            <i class="bi bi-pencil-square"></i>
+          </button>
+          <button class="btn btn-danger anular-presupuesto" ${disabled} title="Anular">
+            <i class="bi bi-x-circle"></i>
+          </button>
+        </td>
+      </tr>`);
+  });
+}
+
+function cargarTablaPresupuesto(){
+  const datos = ejecutarAjax("controladores/presupuestos_compra.php","leer=1");
+  renderTablaPresupuestos(datos);
 }
 
 $(document).on("click",".editar-presupuesto",function(){
@@ -453,43 +459,29 @@ $(document).on("change","#estado_filtro",function(){
   buscarPresupuesto();
 });
 
+$(document).on("change","#f_desde, #f_hasta", function(){
+  buscarPresupuesto();
+});
+
 function buscarPresupuesto(){
-  const desc = encodeURIComponent($("#b_presupuesto").val() || "");
-  const est  = encodeURIComponent($("#estado_filtro").val() || "");
-  let datos = ejecutarAjax(
+  const desc   = encodeURIComponent($("#b_presupuesto").val() || "");
+  const est    = encodeURIComponent($("#estado_filtro").val() || "");
+  const fDesde = encodeURIComponent($("#f_desde").val() || "");
+  const fHasta = encodeURIComponent($("#f_hasta").val() || "");
+  const datos = ejecutarAjax(
     "controladores/presupuestos_compra.php",
-    "leer_descripcion="+desc+"&estado="+est
+    "leer_descripcion="+desc+"&estado="+est+"&f_desde="+fDesde+"&f_hasta="+fHasta
   );
-  if(datos === "0"){
-    $("#datos_tb").html("NO HAY REGISTROS");
-  }else{
-    $("#datos_tb").html("");
-    let json = JSON.parse(datos);
-    json.map(function(it){
-      const disabled = it.estado === 'ANULADO' ? 'disabled' : '';
-      $("#datos_tb").append(`
-        <tr>
-          <td>${it.id_presupuesto}</td>
-          <td class="text-start">${it.proveedor}</td>
-          <td>${it.fecha}</td>
-          <td>${it.validez}</td>
-          <td class="text-end">${fmt0(toNumberPY(it.total_estimado))}</td>
-          <td>${badgeEstado(it.estado)}</td>
-          <td>
-            <button class="btn btn-info ver-detalle" ${disabled} title="Imprimir">
-              <i class="bi bi-printer"></i>
-            </button>
-            <button class="btn btn-warning editar-presupuesto" ${disabled} title="Editar">
-              <i class="bi bi-pencil-square"></i>
-            </button>
-            <button class="btn btn-danger anular-presupuesto" ${disabled} title="Anular">
-              <i class="bi bi-x-circle"></i>
-            </button>
-          </td>
-        </tr>`);
-    });
-  }
+  renderTablaPresupuestos(datos);
 }
+
+$(document).on("click", "#limpiar_busqueda_btn", function(){
+  $("#b_presupuesto").val("");
+  $("#estado_filtro").val("");
+  $("#f_desde").val("");
+  $("#f_hasta").val("");
+  buscarPresupuesto();
+});
 
 function imprimirPresupuesto(id){
   let presupuestoData = ejecutarAjax("controladores/presupuestos_compra.php", "leer_id=" + id);


### PR DESCRIPTION
## Summary
- add render helper that updates table and badge with total budgets
- support filtering budgets by status, search term, and date range
- expose new range filters to backend query

## Testing
- `php -l controladores/presupuestos_compra.php`
- `node --check vistas/presupuestos_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_689cad662c7883259f2b7a7910067d33