### PR TITLE
feat: expand remision header and simplify detail

### DIFF
--- a/controladores/detalle_remision.php
+++ b/controladores/detalle_remision.php
@@ -13,23 +13,15 @@ if (isset($_POST['guardar'])) {
         return;
     }
 
-    if (floatval($datos['precio_unitario']) <= 0) {
-        echo 'PRECIO_INVALIDO';
-        return;
-    }
-
     $query = $cn->prepare(
-        "INSERT INTO detalle_remision
-        (id_remision, id_producto, cantidad, precio_unitario, subtotal)
-        VALUES (:id_remision, :id_producto, :cantidad, :precio_unitario, :subtotal)"
+        "INSERT INTO detalle_remision (id_remision, id_producto, cantidad, precio_unitario, subtotal)
+        VALUES (:id_remision, :id_producto, :cantidad, 0, 0)"
     );
 
     $query->execute([
         'id_remision' => $datos['id_remision'],
         'id_producto' => $datos['id_producto'],
-        'cantidad' => $datos['cantidad'],
-        'precio_unitario' => $datos['precio_unitario'],
-        'subtotal' => $datos['subtotal']
+        'cantidad' => $datos['cantidad']
     ]);
 
     echo "OK";
@@ -42,12 +34,8 @@ if (isset($_POST['actualizar'])) {
         echo 'CANTIDAD_INVALIDA';
         return;
     }
-    if (floatval($datos['precio_unitario']) <= 0) {
-        echo 'PRECIO_INVALIDO';
-        return;
-    }
     $query = $cn->prepare(
-        "UPDATE detalle_remision SET id_remision = :id_remision, id_producto = :id_producto, cantidad = :cantidad, precio_unitario = :precio_unitario, subtotal = :subtotal WHERE id_detalle_remision = :id_detalle_remision"
+        "UPDATE detalle_remision SET id_remision = :id_remision, id_producto = :id_producto, cantidad = :cantidad, precio_unitario = 0, subtotal = 0 WHERE id_detalle_remision = :id_detalle_remision"
     );
     $query->execute($datos);
 }
@@ -67,7 +55,7 @@ if (isset($_POST['eliminar_por_remision'])) {
 // LISTAR DETALLES
 if (isset($_POST['leer'])) {
     $sql =
-        "SELECT d.id_detalle_remision, d.id_remision, d.id_producto, p.nombre AS producto, d.cantidad, d.precio_unitario, d.subtotal FROM detalle_remision d LEFT JOIN productos p ON d.id_producto = p.producto_id";
+        "SELECT d.id_detalle_remision, d.id_remision, d.id_producto, p.nombre AS producto, d.cantidad FROM detalle_remision d LEFT JOIN productos p ON d.id_producto = p.producto_id";
     $params = [];
     if (!empty($_POST['id_remision'])) {
         $sql .= " WHERE d.id_remision = :id_remision";
@@ -82,7 +70,7 @@ if (isset($_POST['leer'])) {
 // LEER POR ID
 if (isset($_POST['leer_id'])) {
     $query = $cn->prepare(
-        "SELECT id_detalle_remision, id_remision, id_producto, cantidad, precio_unitario, subtotal FROM detalle_remision WHERE id_detalle_remision = :id"
+        "SELECT id_detalle_remision, id_remision, id_producto, cantidad FROM detalle_remision WHERE id_detalle_remision = :id"
     );
     $query->execute(['id' => $_POST['leer_id']]);
     echo $query->rowCount() ? json_encode($query->fetch(PDO::FETCH_OBJ)) : '0';
@@ -92,7 +80,7 @@ if (isset($_POST['leer_id'])) {
 if (isset($_POST['leer_descripcion'])) {
     $filtro = '%' . $_POST['leer_descripcion'] . '%';
     $sql =
-        "SELECT d.id_detalle_remision, d.id_remision, d.id_producto, p.nombre AS producto, d.cantidad, d.precio_unitario, d.subtotal FROM detalle_remision d LEFT JOIN productos p ON d.id_producto = p.producto_id WHERE CONCAT(d.id_detalle_remision, p.nombre, d.id_remision) LIKE :filtro";
+        "SELECT d.id_detalle_remision, d.id_remision, d.id_producto, p.nombre AS producto, d.cantidad FROM detalle_remision d LEFT JOIN productos p ON d.id_producto = p.producto_id WHERE CONCAT(d.id_detalle_remision, p.nombre, d.id_remision) LIKE :filtro";
     $params = ['filtro' => $filtro];
     if (!empty($_POST['id_remision'])) {
         $sql .= " AND d.id_remision = :id_remision";

--- a/controladores/test_remision.php
+++ b/controladores/test_remision.php
@@ -4,18 +4,12 @@ require_once '../conexion/db.php';
 try {
     $db = new DB();
     $cn = $db->conectar();
-    $query = $cn->prepare("
-        SELECT r.id_remision, r.fecha_remision, r.id_cliente, c.nombre_apellido AS cliente,
-               r.observacion, r.estado, IFNULL(SUM(d.subtotal),0) AS total
-        FROM remision r
-        LEFT JOIN cliente c ON r.id_cliente = c.id_cliente
-        LEFT JOIN detalle_remision d ON r.id_remision = d.id_remision
-        GROUP BY r.id_remision, r.fecha_remision, r.id_cliente, c.nombre_apellido, r.observacion, r.estado
-        ORDER BY r.id_remision DESC
-    ");
+    $query = $cn->prepare("\n        SELECT r.id_remision, r.fecha_remision, r.id_cliente, c.nombre_apellido AS cliente,\n               r.observacion, r.estado\n        FROM remision r\n        LEFT JOIN clientes c ON r.id_cliente = c.id_cliente\n        ORDER BY r.id_remision DESC\n    ");
     $query->execute();
     header('Content-Type: application/json');
     echo json_encode($query->fetchAll(PDO::FETCH_OBJ));
 } catch (Exception $e) {
-    echo "ERROR: " . $e->getMessage();  // Temporal para ver errores reales
+    echo "ERROR: " . $e->getMessage();
 }
+?>
+

--- a/paginas/referenciales/remision/agregar.php
+++ b/paginas/referenciales/remision/agregar.php
@@ -11,15 +11,46 @@
 
     <div class="card-body">
       <div class="row g-3">
-        <div class="col-md-6">
+        <div class="col-md-4">
           <label for="id_cliente_lst" class="form-label fw-semibold">Cliente</label>
           <select id="id_cliente_lst" class="form-select" aria-label="Cliente"></select>
         </div>
+        <div class="col-md-4">
+          <label for="id_conductor_lst" class="form-label fw-semibold">Conductor</label>
+          <select id="id_conductor_lst" class="form-select" aria-label="Conductor"></select>
+        </div>
+        <div class="col-md-4">
+          <label for="movil_txt" class="form-label fw-semibold">Móvil</label>
+          <input type="text" id="movil_txt" class="form-control" placeholder="Móvil">
+        </div>
+
         <div class="col-md-3">
           <label for="fecha_txt" class="form-label fw-semibold">Fecha</label>
           <input type="date" id="fecha_txt" class="form-control" value="<?php echo date('Y-m-d'); ?>">
         </div>
         <div class="col-md-3">
+          <label for="punto_salida_lst" class="form-label fw-semibold">Punto de salida</label>
+          <select id="punto_salida_lst" class="form-select" aria-label="Punto de salida"></select>
+        </div>
+        <div class="col-md-3">
+          <label for="punto_llegada_lst" class="form-label fw-semibold">Punto de llegada</label>
+          <select id="punto_llegada_lst" class="form-select" aria-label="Punto de llegada"></select>
+        </div>
+        <div class="col-md-3">
+          <label for="tipo_transporte_lst" class="form-label fw-semibold">Tipo de transporte</label>
+          <select id="tipo_transporte_lst" class="form-select">
+            <option value="">-- Seleccione --</option>
+            <option value="TERRESTRE">Terrestre</option>
+            <option value="AEREO">Aéreo</option>
+            <option value="FLUVIAL">Fluvial</option>
+          </select>
+        </div>
+
+        <div class="col-md-4">
+          <label for="factura_relacionada_txt" class="form-label fw-semibold">Factura relacionada</label>
+          <input type="text" id="factura_relacionada_txt" class="form-control" placeholder="Nro. factura">
+        </div>
+        <div class="col-md-8">
           <label for="observacion_txt" class="form-label fw-semibold">Observación</label>
           <input type="text" id="observacion_txt" class="form-control" placeholder="Opcional">
         </div>
@@ -48,22 +79,6 @@
           <input type="number" id="cantidad_txt" class="form-control" min="1" placeholder="0">
         </div>
 
-        <div class="col-md-2">
-          <label for="precio_unitario_txt" class="form-label fw-semibold">Precio Unitario</label>
-          <div class="input-group">
-            <span class="input-group-text">Gs.</span>
-            <input type="text" id="precio_unitario_txt" class="form-control" inputmode="numeric" placeholder="0">
-          </div>
-        </div>
-
-        <div class="col-md-2">
-          <label for="subtotal_txt" class="form-label fw-semibold">Subtotal</label>
-          <div class="input-group">
-            <span class="input-group-text">Gs.</span>
-            <input type="text" id="subtotal_txt" class="form-control" readonly>
-          </div>
-        </div>
-
         <div class="col-md-1 d-grid">
           <button class="btn btn-primary" onclick="agregarDetalleRemision(); return false;">
             <i class="bi bi-plus-lg"></i>
@@ -77,21 +92,12 @@
             <tr>
               <th>Producto</th>
               <th class="text-end">Cantidad</th>
-              <th class="text-end">Precio Unitario</th>
-              <th class="text-end">Subtotal</th>
               <th>Acción</th>
             </tr>
           </thead>
           <tbody id="detalle_remision_tb">
-            <!-- filas dinámicas: en la celda de subtotal usar class="text-end cell-subtotal" -->
+            <!-- filas dinámicas -->
           </tbody>
-          <tfoot class="table-light">
-            <tr>
-              <th colspan="3" class="text-end fw-bold">Total</th>
-              <th id="total_general_txt" class="text-end fs-5">0</th>
-              <th></th>
-            </tr>
-          </tfoot>
         </table>
       </div>
     </div>

--- a/paginas/referenciales/remision/listar.php
+++ b/paginas/referenciales/remision/listar.php
@@ -56,12 +56,11 @@
         <table class="table table-striped table-hover align-middle text-center mb-0">
           <thead class="table-primary position-sticky top-0" style="z-index:1;">
             <tr>
-              <th style="width: 8%">#</th>
-              <th style="width: 16%">Fecha</th>
-              <th style="width: 36%">Cliente</th>
-              <th class="text-end" style="width: 14%">Total</th>
-              <th style="width: 12%">Estado</th>
-              <th style="width: 14%">Operaciones</th>
+              <th style="width: 10%">#</th>
+              <th style="width: 20%">Fecha</th>
+              <th style="width: 40%">Cliente</th>
+              <th style="width: 15%">Estado</th>
+              <th style="width: 15%">Operaciones</th>
             </tr>
           </thead>
           <tbody id="remision_datos_tb">


### PR DESCRIPTION
## Summary
- remove unit price and subtotal from remission details and views
- add conductor, vehicle, route points, transport type and linked invoice to remission header
- validate distinct origin/destination and update controllers accordingly

## Testing
- `php -l paginas/referenciales/remision/agregar.php`
- `php -l paginas/referenciales/remision/listar.php`
- `php -l controladores/remision.php`
- `php -l controladores/detalle_remision.php`
- `php -l controladores/test_remision.php`
- `node -c vistas/remision.js`

------
https://chatgpt.com/codex/tasks/task_e_689cad14ca30832586bd56b7e6ab84aa