### PR TITLE
Filter remision product list by product type

### DIFF
--- a/controladores/productos.php
+++ b/controladores/productos.php
@@ -61,12 +61,20 @@ if (isset($_POST['leer'])) {
 }
 
 if (isset($_POST['leerActivo'])) {
-    $query = $db->prepare(
+    $tipo = $_POST['tipo'] ?? '';
+    $sql =
         "SELECT producto_id, nombre, descripcion, precio, tipo, estado " .
-        "FROM productos WHERE estado = 'ACTIVO' " .
-        "ORDER BY producto_id DESC"
-    );
-    $query->execute();
+        "FROM productos WHERE estado = 'ACTIVO'";
+    if ($tipo !== '') {
+        $sql .= " AND tipo = :tipo";
+    }
+    $sql .= " ORDER BY producto_id DESC";
+    $query = $db->prepare($sql);
+    $params = [];
+    if ($tipo !== '') {
+        $params['tipo'] = $tipo;
+    }
+    $query->execute($params);
     echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
 

--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -42,7 +42,7 @@ function renderListaClientes(arr){
 }
 
 function cargarListaProductos(){
-    let datos = ejecutarAjax("controladores/productos.php","leerActivo=1");
+    let datos = ejecutarAjax("controladores/productos.php","leerActivo=1&tipo=PRODUCTO");
     if(datos !== "0"){
         listaProductos = JSON.parse(datos);
         renderListaProductos(listaProductos);


### PR DESCRIPTION
## Summary
- allow product controller to filter active items by `tipo`
- load only `PRODUCTO` items in remision product select

## Testing
- `php -l controladores/productos.php`
- `node --check vistas/remision.js`


------
https://chatgpt.com/codex/tasks/task_e_689cc2b150048325bdebe3d2fb2c14ca