### PR TITLE
Exclude service products from remision product selector

### DIFF
--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -52,7 +52,9 @@ function cargarListaProductos(){
 function renderListaProductos(arr){
     let select = $("#id_producto_lst");
     select.html('<option value="">-- Seleccione un producto --</option>');
-    arr.forEach(p => select.append(`<option value="${p.producto_id}">${p.nombre}</option>`));
+    arr
+        .filter(p => p.tipo !== 'SERVICIO')
+        .forEach(p => select.append(`<option value="${p.producto_id}">${p.nombre}</option>`));
 }
 
 function cargarListaConductores(){


### PR DESCRIPTION
## Summary
- Hide `SERVICIO` type items from the Remisión product dropdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cc429c0d483259f2c512ed4c4d3b9