### PR TITLE
Fix order table rendering when backend returns non-array data

### DIFF
--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -582,6 +582,14 @@ function cargarTablaOrden(){
 function renderTablaOrden(arr){
   let tbody = $("#orden_datos_tb");
   tbody.html("");
+
+  // Asegurarse de que 'arr' sea iterable. Si el backend devuelve un
+  // objeto o un valor no esperado, convertirlo a un arreglo vacío para
+  // evitar errores de ejecución al usar `forEach`.
+  if (!Array.isArray(arr)) {
+    arr = [];
+  }
+
   arr.forEach(function(o){
     const disabled = o.estado === 'ANULADO' ? 'disabled' : '';
     tbody.append(`<tr>


### PR DESCRIPTION
## Summary
- Ensure `renderTablaOrden` verifies that the response is an array before iterating, preventing runtime errors

## Testing
- `node --check vistas/orden_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_689ccb9c34488325be9d0ed8587531e4