### PR TITLE
Add color mapping for closed status badges

### DIFF
--- a/vistas/recepcion.js
+++ b/vistas/recepcion.js
@@ -289,7 +289,8 @@ function imprimirRecepcion(id, auto = true, copias = 1){
       estUC === "ANULADO"       ? "bg-danger" :
       estUC === "DIAGNOSTICADO" ? "bg-info text-dark" :
       estUC === "PENDIENTE"     ? "bg-warning text-dark" :
-      estUC === "ACTIVO"        ? "bg-primary" :
+      estUC === "CERRADA"       ? "bg-primary" :
+      estUC === "ACTIVO"        ? "bg-success" :
                                   "bg-secondary";
 
   // Datos de empresa (ajusta a tu realidad)

--- a/vistas/util.js
+++ b/vistas/util.js
@@ -142,6 +142,8 @@ function badgeEstado(estado) {
         clase = 'warning text-dark';
     } else if (est === 'DIAGNOSTICADO') {
         clase = 'info';
+    } else if (est === 'CERRADA') {
+        clase = 'primary';
     } else if (est === 'INACTIVO' || est === 'ANULADO') {
         clase = 'danger';
     }


### PR DESCRIPTION
## Summary
- Map `CERRADA` state to a blue badge in `badgeEstado` helper
- Include `CERRADA` in reception print badge logic and align active badge color

## Testing
- `node --check vistas/util.js vistas/recepcion.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd23b47b08325883fd08282036afa