### PR TITLE
Add inline client creation to recepcion form

### DIFF
--- a/paginas/referenciales/recepcion/agregar.php
+++ b/paginas/referenciales/recepcion/agregar.php
@@ -37,6 +37,9 @@
           <div class="input-group">
             <span class="input-group-text"><i class="bi bi-person-badge"></i></span>
             <select id="id_cliente_lst" class="form-select"></select>
+            <button id="nuevo_cliente_btn" class="btn btn-outline-primary" type="button" title="Agregar cliente">
+              <i class="bi bi-plus-lg"></i>
+            </button>
           </div>
         </div>
 
@@ -157,6 +160,19 @@
           <i class="bi bi-save me-1"></i> Guardar
         </button>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- Modal: Agregar Cliente -->
+<div class="modal fade" id="modal_nuevo_cliente" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Agregar Cliente</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <div class="modal-body p-0"></div>
     </div>
   </div>
 </div>

--- a/vistas/recepcion.js
+++ b/vistas/recepcion.js
@@ -65,6 +65,62 @@ $(document).on('change', '#id_cliente_lst', function () {
   $('#direccion_txt').val(dir);
 });
 
+// Abrir modal para agregar nuevo cliente
+$(document).on('click', '#nuevo_cliente_btn', function(){
+  const contenido = dameContenido('paginas/referenciales/cliente/agregar.php');
+  const $modal = $('#modal_nuevo_cliente');
+  $modal.find('.modal-body').html(contenido);
+  // reemplazar acciones de los botones del formulario cargado
+  $modal.find('.btn-success').attr('onclick','guardarClienteDesdeModal(); return false;');
+  $modal.find('.btn-danger').attr('onclick',"$('#modal_nuevo_cliente').modal('hide'); return false;");
+  cargarListaCiudad('#modal_nuevo_cliente #ciudad_lst');
+  $modal.modal('show');
+});
+
+function guardarClienteDesdeModal(){
+  const $m = $('#modal_nuevo_cliente');
+  const nombre = $m.find('#nombre_txt').val().trim();
+  const ruc = $m.find('#ruc_txt').val().trim();
+  const dir = $m.find('#direccion_txt').val().trim();
+  const tel = $m.find('#telefono_txt').val().trim();
+  const ciudad = $m.find('#ciudad_lst').val();
+  const estado = $m.find('#estado_lst').val();
+
+  if(nombre.length===0){ mensaje_dialogo_info_ERROR('Debes ingresar el nombre y apellido', 'ATENCION'); return; }
+  if(ruc.length===0){ mensaje_dialogo_info_ERROR('Debes ingresar el RUC', 'ATENCION'); return; }
+  if(dir.length===0){ mensaje_dialogo_info_ERROR('Debes ingresar la Direccion', 'ATENCION'); return; }
+  if(tel.length===0){ mensaje_dialogo_info_ERROR('Debes ingresar el Telefono', 'ATENCION'); return; }
+  if(ciudad==="0" || ciudad===""){ mensaje_dialogo_info_ERROR('Debes ingresar la ciudad', 'ATENCION'); return; }
+  if(!/^[0-9\-]+$/.test(ruc)){ mensaje_dialogo_info_ERROR('El RUC solo puede contener números y guiones (-)', 'ATENCIÓN'); return; }
+  if(!/^[0-9+]+$/.test(tel)){ mensaje_dialogo_info_ERROR('El teléfono solo puede contener números y el símbolo +', 'ATENCIÓN'); return; }
+
+  let datos={
+    nombre_apellido:nombre,
+    ruc:ruc,
+    direccion:dir,
+    id_ciudad:ciudad,
+    telefono:tel,
+    estado:estado
+  };
+
+  let res = ejecutarAjax('controladores/cliente.php','guardar='+JSON.stringify(datos));
+  if(res === 'duplicado'){ mensaje_dialogo_info_ERROR('El RUC ya esta registrado con otro cliente', 'ATENCION'); return; }
+  mensaje_confirmacion('Guardado correctamente');
+
+  // Obtener ID del nuevo cliente usando el RUC
+  let nuevoId = '';
+  let consulta = ejecutarAjax('controladores/cliente.php','leer_descripcion='+ruc);
+  if(consulta !== '0'){
+    let js = JSON.parse(consulta);
+    let found = js.find(c=>c.ruc===ruc);
+    if(found) nuevoId = found.id_cliente;
+  }
+
+  $m.modal('hide');
+  cargarListaClientes(nuevoId);
+}
+window.guardarClienteDesdeModal = guardarClienteDesdeModal;
+
 // ========================= Accesorios entregados (chips) =========================
 let accesoriosTmp = []; // array temporal de accesorios para el equipo en edición
 


### PR DESCRIPTION
## Summary
- allow adding clients without leaving recepcion by inserting a modal button next to the client field
- handle client creation from modal and refresh client list

## Testing
- `php -l paginas/referenciales/recepcion/agregar.php`
- `node --check vistas/recepcion.js`


------
https://chatgpt.com/codex/tasks/task_e_689cd3b831c883259762451a4681b2ee