### PR TITLE
Filtrar productos de tipo PRODUCTO en remisión

### DIFF
--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -115,7 +115,7 @@ function renderListaProductos(arr){
   const $select = $("#id_producto_lst");
   $select.html('<option value="">-- Seleccione un producto --</option>');
   arr
-    .filter(p => p.tipo !== 'SERVICIO')
+    .filter(p => p.tipo === 'PRODUCTO')
     .forEach(p => $select.append(`<option value="${p.producto_id}">${p.nombre}</option>`));
 }
 


### PR DESCRIPTION
## Summary
- Mostrar sólo productos de tipo PRODUCTO en el formulario de remisiones

## Testing
- `node --check vistas/remision.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689cd8aa39088325aff5ab6bdcfd6954