### PR TITLE
Hide inactive points from Remisión select lists

### DIFF
--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -144,10 +144,12 @@ function renderListaPuntos(arr){
   const $llegada = $("#punto_llegada_lst");
   $salida.html('<option value="">-- Seleccione punto --</option>');
   $llegada.html('<option value="">-- Seleccione punto --</option>');
-  arr.forEach(p => {
-    $salida.append(`<option value="${p.id_punto}">${p.nombre}</option>`);
-    $llegada.append(`<option value="${p.id_punto}">${p.nombre}</option>`);
-  });
+  arr
+    .filter(p => p.estado === "ACTIVO")
+    .forEach(p => {
+      $salida.append(`<option value="${p.id_punto}">${p.nombre}</option>`);
+      $llegada.append(`<option value="${p.id_punto}">${p.nombre}</option>`);
+    });
 }
 
 /* =========================


### PR DESCRIPTION
## Summary
- filter points list so only active ones appear in Remisión selects

## Testing
- `node --check vistas/remision.js`


------
https://chatgpt.com/codex/tasks/task_e_689cdcc34340832587c8dbda6d76de32