### PR TITLE
Mostrar RUC en listas de clientes y proveedores

### DIFF
--- a/vistas/nota_credito.js
+++ b/vistas/nota_credito.js
@@ -33,7 +33,10 @@ function cargarListaClientes(selectedId = ""){
         listaClientes = JSON.parse(datos);
         let select = $("#id_cliente_lst");
         select.html('<option value="">-- Seleccione un cliente --</option>');
-        listaClientes.forEach(c => select.append(`<option value="${c.id_cliente}" data-ruc="${c.ruc}">${c.nombre_apellido}</option>`));
+        listaClientes.forEach(c => select.append(`
+          <option value="${c.id_cliente}" data-ruc="${c.ruc}">
+            ${c.nombre_apellido} | ruc: ${c.ruc}
+          </option>`));
         if(selectedId){ select.val(selectedId).trigger('change'); }
     }
 }

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -83,7 +83,11 @@ function renderListaProveedores(arr){
   let select = $("#id_proveedor_lst");
   select.html('<option value="">-- Seleccione un proveedor --</option>');
   arr.forEach(function(p){
-    select.append(`<option value="${p.id_proveedor}">${p.razon_social}</option>`);
+    select.append(`
+      <option value="${p.id_proveedor}" data-ruc="${p.ruc}">
+        ${p.razon_social} | ruc: ${p.ruc}
+      </option>
+    `);
   });
 }
 

--- a/vistas/recepcion.js
+++ b/vistas/recepcion.js
@@ -44,7 +44,8 @@ function renderListaClientes(arr, selectedId = "") {
   arr.forEach(c => {
     const id  = c.id_cliente ?? c.cod_cliente ?? c.id;
     const nom = c.nombre_apellido ?? c.nombre_cliente ?? c.nombre;
-    $sel.append(`<option value="${id}">${nom}</option>`);
+    const ruc = c.ruc ?? c.ruc_cliente ?? '';
+    $sel.append(`<option value="${id}">${nom} | ruc: ${ruc}</option>`);
   });
   if (selectedId) $sel.val(selectedId).trigger('change'); // prellena al editar
 }

--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -45,7 +45,13 @@ function cargarListaClientes(selectedId = ""){
 function renderListaClientes(arr, selectedId = ""){
   const $select = $("#id_cliente_lst");
   $select.html('<option value="">-- Seleccione un cliente --</option>');
-  arr.forEach(c => $select.append(`<option value="${c.id_cliente}">${c.nombre_apellido}</option>`));
+  arr.forEach(c => {
+    $select.append(`
+      <option value="${c.id_cliente}" data-ruc="${c.ruc}">
+        ${c.nombre_apellido} | ruc: ${c.ruc}
+      </option>
+    `);
+  });
   if(selectedId) $select.val(selectedId).trigger('change');
 }
 


### PR DESCRIPTION
## Summary
- Mostrar RUC en las opciones de proveedor para presupuestos de compra
- Incluir RUC junto al nombre del cliente en formularios de recepción, remisión y nota de crédito

## Testing
- `node --check vistas/presupuestos_compra.js`
- `node --check vistas/recepcion.js`
- `node --check vistas/remision.js`
- `node --check vistas/nota_credito.js`


------
https://chatgpt.com/codex/tasks/task_e_689cdddf744c8325adff43f6ad04e68f