### PR TITLE
Filtrar conductores inactivos en remisión

### DIFF
--- a/controladores/conductor.php
+++ b/controladores/conductor.php
@@ -60,6 +60,14 @@ if (isset($_POST['leer'])) {
     echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
 }
 
+if (isset($_POST['leerActivo'])) {
+    $query = $db->prepare(
+        "SELECT id_conductor, nombre, cedula, telefono, licencia_conduccion, estado FROM conductor WHERE estado = 'ACTIVO' ORDER BY id_conductor DESC"
+    );
+    $query->execute();
+    echo $query->rowCount() ? json_encode($query->fetchAll(PDO::FETCH_OBJ)) : '0';
+}
+
 if (isset($_POST['leer_descripcion'])) {
     $filtro = '%' . $_POST['leer_descripcion'] . '%';
     $query = $db->prepare(

--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -120,7 +120,7 @@ function renderListaProductos(arr){
 }
 
 function cargarListaConductores(){
-  const datos = ejecutarAjax("controladores/conductor.php","leer=1");
+  const datos = ejecutarAjax("controladores/conductor.php","leerActivo=1");
   if(datos !== "0"){
     listaConductores = JSON.parse(datos);
     renderListaConductores(listaConductores);
@@ -129,7 +129,9 @@ function cargarListaConductores(){
 function renderListaConductores(arr){
   const $select = $("#id_conductor_lst");
   $select.html('<option value="">-- Seleccione un conductor --</option>');
-  arr.forEach(c => $select.append(`<option value="${c.id_conductor}">${c.nombre}</option>`));
+  arr
+    .filter(c => c.estado === 'ACTIVO')
+    .forEach(c => $select.append(`<option value="${c.id_conductor}">${c.nombre}</option>`));
 }
 
 function cargarListaPuntos(){


### PR DESCRIPTION
## Summary
- Add `leerActivo` endpoint to return only active drivers
- Update remisión UI to populate driver list with active conductors only

## Testing
- `php -l controladores/conductor.php`
- `node --check vistas/remision.js`


------
https://chatgpt.com/codex/tasks/task_e_689cdf0d3b54832580b3d54dc062d6bf