### PR TITLE
Ocultar RUC tras seleccionar cliente o proveedor

### DIFF
--- a/vistas/nota_credito.js
+++ b/vistas/nota_credito.js
@@ -34,7 +34,7 @@ function cargarListaClientes(selectedId = ""){
         let select = $("#id_cliente_lst");
         select.html('<option value="">-- Seleccione un cliente --</option>');
         listaClientes.forEach(c => select.append(`
-          <option value="${c.id_cliente}" data-ruc="${c.ruc}">
+          <option value="${c.id_cliente}" data-ruc="${c.ruc}" data-nombre="${c.nombre_apellido}" data-full="${c.nombre_apellido} | ruc: ${c.ruc}">
             ${c.nombre_apellido} | ruc: ${c.ruc}
           </option>`));
         if(selectedId){ select.val(selectedId).trigger('change'); }

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -83,9 +83,12 @@ function renderListaProveedores(arr){
   let select = $("#id_proveedor_lst");
   select.html('<option value="">-- Seleccione un proveedor --</option>');
   arr.forEach(function(p){
+    const nombre = p.razon_social;
+    const ruc = p.ruc;
+    const full = `${nombre} | ruc: ${ruc}`;
     select.append(`
-      <option value="${p.id_proveedor}" data-ruc="${p.ruc}">
-        ${p.razon_social} | ruc: ${p.ruc}
+      <option value="${p.id_proveedor}" data-ruc="${ruc}" data-nombre="${nombre}" data-full="${full}">
+        ${full}
       </option>
     `);
   });

--- a/vistas/recepcion.js
+++ b/vistas/recepcion.js
@@ -45,7 +45,8 @@ function renderListaClientes(arr, selectedId = "") {
     const id  = c.id_cliente ?? c.cod_cliente ?? c.id;
     const nom = c.nombre_apellido ?? c.nombre_cliente ?? c.nombre;
     const ruc = c.ruc ?? c.ruc_cliente ?? '';
-    $sel.append(`<option value="${id}">${nom} | ruc: ${ruc}</option>`);
+    const full = `${nom} | ruc: ${ruc}`;
+    $sel.append(`<option value="${id}" data-ruc="${ruc}" data-nombre="${nom}" data-full="${full}">${full}</option>`);
   });
   if (selectedId) $sel.val(selectedId).trigger('change'); // prellena al editar
 }

--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -46,9 +46,12 @@ function renderListaClientes(arr, selectedId = ""){
   const $select = $("#id_cliente_lst");
   $select.html('<option value="">-- Seleccione un cliente --</option>');
   arr.forEach(c => {
+    const nombre = c.nombre_apellido;
+    const ruc = c.ruc;
+    const full = `${nombre} | ruc: ${ruc}`;
     $select.append(`
-      <option value="${c.id_cliente}" data-ruc="${c.ruc}">
-        ${c.nombre_apellido} | ruc: ${c.ruc}
+      <option value="${c.id_cliente}" data-ruc="${ruc}" data-nombre="${nombre}" data-full="${full}">
+        ${full}
       </option>
     `);
   });

--- a/vistas/util.js
+++ b/vistas/util.js
@@ -801,4 +801,17 @@ function cargarDataTable(componente, lista) {
         });
     }
 }
-;
+
+// Restaurar texto completo en los combos al enfocar
+$(document).on('focus', 'select', function(){
+  $(this).find('option[data-full]').each(function(){
+    $(this).text($(this).data('full'));
+  });
+});
+
+// Al seleccionar, mostrar solo el nombre
+$(document).on('change', 'select', function(){
+  const $opt = $(this).find('option:selected');
+  const nombre = $opt.data('nombre');
+  if(nombre){ $opt.text(nombre); }
+});


### PR DESCRIPTION
## Summary
- Mostrar el RUC solo dentro del desplegable y ocultarlo una vez elegido el cliente o proveedor
- Añadir manejadores globales para restaurar el texto completo al enfocar los select y mostrar solo el nombre al seleccionar

## Testing
- `npm test` *(falla: no se encontró package.json)*
- `node --check vistas/presupuestos_compra.js && echo 'presupuestos_compra ok'
node --check vistas/nota_credito.js && echo 'nota_credito ok'
node --check vistas/remision.js && echo 'remision ok'
node --check vistas/recepcion.js && echo 'recepcion ok'
node --check vistas/util.js && echo 'util ok'`

------
https://chatgpt.com/codex/tasks/task_e_689ce0001e0c83258a33984740873d6b