### PR TITLE
Mostrar solo el nombre en selects de proveedores y clientes

### DIFF
--- a/vistas/nota_credito.js
+++ b/vistas/nota_credito.js
@@ -34,8 +34,8 @@ function cargarListaClientes(selectedId = ""){
         let select = $("#id_cliente_lst");
         select.html('<option value="">-- Seleccione un cliente --</option>');
         listaClientes.forEach(c => select.append(`
-          <option value="${c.id_cliente}" data-ruc="${c.ruc}" data-nombre="${c.nombre_apellido}" data-full="${c.nombre_apellido} | ruc: ${c.ruc}">
-            ${c.nombre_apellido} | ruc: ${c.ruc}
+          <option value="${c.id_cliente}" data-ruc="${c.ruc}" data-nombre="${c.nombre_apellido}">
+            ${c.nombre_apellido}
           </option>`));
         if(selectedId){ select.val(selectedId).trigger('change'); }
     }

--- a/vistas/presupuestos_compra.js
+++ b/vistas/presupuestos_compra.js
@@ -85,10 +85,9 @@ function renderListaProveedores(arr){
   arr.forEach(function(p){
     const nombre = p.razon_social;
     const ruc = p.ruc;
-    const full = `${nombre} | ruc: ${ruc}`;
     select.append(`
-      <option value="${p.id_proveedor}" data-ruc="${ruc}" data-nombre="${nombre}" data-full="${full}">
-        ${full}
+      <option value="${p.id_proveedor}" data-ruc="${ruc}" data-nombre="${nombre}">
+        ${nombre}
       </option>
     `);
   });

--- a/vistas/recepcion.js
+++ b/vistas/recepcion.js
@@ -45,8 +45,7 @@ function renderListaClientes(arr, selectedId = "") {
     const id  = c.id_cliente ?? c.cod_cliente ?? c.id;
     const nom = c.nombre_apellido ?? c.nombre_cliente ?? c.nombre;
     const ruc = c.ruc ?? c.ruc_cliente ?? '';
-    const full = `${nom} | ruc: ${ruc}`;
-    $sel.append(`<option value="${id}" data-ruc="${ruc}" data-nombre="${nom}" data-full="${full}">${full}</option>`);
+    $sel.append(`<option value="${id}" data-ruc="${ruc}" data-nombre="${nom}">${nom}</option>`);
   });
   if (selectedId) $sel.val(selectedId).trigger('change'); // prellena al editar
 }

--- a/vistas/remision.js
+++ b/vistas/remision.js
@@ -48,10 +48,9 @@ function renderListaClientes(arr, selectedId = ""){
   arr.forEach(c => {
     const nombre = c.nombre_apellido;
     const ruc = c.ruc;
-    const full = `${nombre} | ruc: ${ruc}`;
     $select.append(`
-      <option value="${c.id_cliente}" data-ruc="${ruc}" data-nombre="${nombre}" data-full="${full}">
-        ${full}
+      <option value="${c.id_cliente}" data-ruc="${ruc}" data-nombre="${nombre}">
+        ${nombre}
       </option>
     `);
   });

--- a/vistas/util.js
+++ b/vistas/util.js
@@ -800,16 +800,3 @@ function cargarDataTable(componente, lista) {
     }
 }
 
-// Restaurar texto completo en los combos al enfocar
-$(document).on('focus', 'select', function(){
-  $(this).find('option[data-full]').each(function(){
-    $(this).text($(this).data('full'));
-  });
-});
-
-// Al seleccionar, mostrar solo el nombre
-$(document).on('change', 'select', function(){
-  const $opt = $(this).find('option:selected');
-  const nombre = $opt.data('nombre');
-  if(nombre){ $opt.text(nombre); }
-});


### PR DESCRIPTION
## Summary
- Simplify provider dropdown to display only the name
- Simplify client dropdowns across modules to show names
- Remove custom select handlers for full-text display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce4a974f483259674711e16fb1dd2