### PR TITLE
Enable diagnostic filters

### DIFF
--- a/controladores/diagnostico.php
+++ b/controladores/diagnostico.php
@@ -31,15 +31,18 @@ if(isset($_POST['eliminar'])){
  $q->execute(['id'=>$_POST['eliminar']]);if($r)actualizarEstadoRecepcion($cn,$r['id_recepcion']);
 }
 if(isset($_POST['leer'])){
- $q=$cn->prepare("SELECT d.id_diagnostico,d.id_recepcion,r.nombre_cliente,d.fecha_inicio,d.estado FROM diagnostico d JOIN recepcion r ON d.id_recepcion=r.id_recepcion ORDER BY d.id_diagnostico DESC");
- $q->execute();echo $q->rowCount()?json_encode($q->fetchAll(PDO::FETCH_OBJ)):'0';
+ $sql="SELECT d.id_diagnostico,d.id_recepcion,r.nombre_cliente,d.fecha_inicio,d.estado FROM diagnostico d JOIN recepcion r ON d.id_recepcion=r.id_recepcion WHERE 1=1";
+ $p=[];
+ if(!empty($_POST['buscar'])){$sql.=" AND CONCAT(d.id_diagnostico,d.id_recepcion,r.nombre_cliente,d.fecha_inicio,d.estado) LIKE :buscar";$p['buscar']='%'.$_POST['buscar'].'%';}
+ if(!empty($_POST['estado'])){$sql.=" AND d.estado=:estado";$p['estado']=$_POST['estado'];}
+ if(!empty($_POST['desde'])){$sql.=" AND DATE(d.fecha_inicio)>=:desde";$p['desde']=$_POST['desde'];}
+ if(!empty($_POST['hasta'])){$sql.=" AND DATE(d.fecha_inicio)<=:hasta";$p['hasta']=$_POST['hasta'];}
+ $sql.=" ORDER BY d.id_diagnostico DESC";
+ $q=$cn->prepare($sql);
+ $q->execute($p);echo $q->rowCount()?json_encode($q->fetchAll(PDO::FETCH_OBJ)):'0';
 }
 if(isset($_POST['leer_id'])){
  $q=$cn->prepare("SELECT id_diagnostico,id_recepcion,id_detalle_recepcion,fecha_inicio,fecha_fin,estado,tecnico_asignado,prioridad,severidad,descripcion_falla,causa_probable,pruebas_realizadas,resultado_pruebas,tiempo_estimado_horas,costo_mano_obra_estimado,costo_repuestos_estimado,costo_total_estimado,aplica_garantia,observaciones FROM diagnostico WHERE id_diagnostico=:id");
  $q->execute(['id'=>$_POST['leer_id']]);echo $q->rowCount()?json_encode($q->fetch(PDO::FETCH_OBJ)):'0';
-}
-if(isset($_POST['leer_descripcion'])){
- $q=$cn->prepare("SELECT d.id_diagnostico,d.id_recepcion,r.nombre_cliente,d.fecha_inicio,d.estado FROM diagnostico d JOIN recepcion r ON d.id_recepcion=r.id_recepcion WHERE CONCAT(d.id_diagnostico,d.id_recepcion,r.nombre_cliente,d.fecha_inicio,d.estado) LIKE :filtro ORDER BY d.id_diagnostico DESC");
- $q->execute(['filtro'=>'%'.$_POST['leer_descripcion'].'%']);echo $q->rowCount()?json_encode($q->fetchAll(PDO::FETCH_OBJ)):'0';
 }
 ?>

--- a/paginas/referenciales/diagnostico/listar.php
+++ b/paginas/referenciales/diagnostico/listar.php
@@ -38,8 +38,8 @@
           <select id="estado_filtro" class="form-select">
             <option value="">Todos</option>
             <option value="PENDIENTE">Pendiente</option>
-            <option value="REALIZADO">Realizado</option>
-            <option value="ANULADO">Anulado</option>
+            <option value="APROBADO">Aprobado</option>
+            <option value="RECHAZADO">Rechazado</option>
           </select>
         </div>
 

--- a/vistas/diagnostico.js
+++ b/vistas/diagnostico.js
@@ -362,7 +362,16 @@ window.imprimirDiagnostico = imprimirDiagnostico;
 
 
 
-function cargarTablaDiagnostico(filtro=""){let q=filtro?"leer_descripcion="+filtro:"leer=1",datos=ejecutarAjax("controladores/diagnostico.php",q);if(datos==="0"){$("#diagnostico_datos_tb").html("NO HAY REGISTROS");$("#diagnostico_count").text(0);}else{let js=JSON.parse(datos);$("#diagnostico_datos_tb").html('');js.forEach(it=>{$("#diagnostico_datos_tb").append(`<tr><td>${it.id_diagnostico}</td><td>${it.id_recepcion} - ${it.nombre_cliente}</td><td>${it.fecha_inicio}</td><td>${badgeEstado(it.estado)}</td><td><button class="btn btn-secondary btn-sm imprimir-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-printer"></i></button> <button class="btn btn-warning btn-sm editar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-pencil-square"></i></button> <button class="btn btn-danger btn-sm eliminar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-trash"></i></button></td></tr>`);});$("#diagnostico_count").text(js.length);}}
+function cargarTablaDiagnostico(){
+  const filtros={
+    leer:1,
+    buscar:$("#b_diagnostico").val(),
+    estado:$("#estado_filtro").val(),
+    desde:$("#f_desde").val(),
+    hasta:$("#f_hasta").val()
+  };
+  let datos=ejecutarAjax("controladores/diagnostico.php",filtros),$tb=$("#diagnostico_datos_tb");
+  if(datos==="0"){$tb.html("NO HAY REGISTROS");$("#diagnostico_count").text(0);}else{let js=JSON.parse(datos);$tb.html('');js.forEach(it=>$tb.append(`<tr><td>${it.id_diagnostico}</td><td>${it.id_recepcion} - ${it.nombre_cliente}</td><td>${it.fecha_inicio}</td><td>${badgeEstado(it.estado)}</td><td><button class="btn btn-secondary btn-sm imprimir-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-printer"></i></button> <button class="btn btn-warning btn-sm editar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-pencil-square"></i></button> <button class="btn btn-danger btn-sm eliminar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-trash"></i></button></td></tr>`));$("#diagnostico_count").text(js.length);}}
 
 function cargarDiagnostico(id){
   // Cargar la vista de edición antes de establecer los datos para evitar
@@ -400,7 +409,15 @@ function cargarDiagnostico(id){
 $(document).on("click",".editar-diagnostico",function(){cargarDiagnostico($(this).data('id'));});
 $(document).on("click",".eliminar-diagnostico",function(){if(confirm("¿Eliminar?")){ejecutarAjax("controladores/diagnostico.php","eliminar="+$(this).data('id'));cargarTablaDiagnostico();cargarPendientesDiagnostico();}});
 $(document).on("click",".imprimir-diagnostico",function(){imprimirDiagnostico($(this).data('id'));});
-$(document).on("keyup","#b_diagnostico",function(){cargarTablaDiagnostico($(this).val());});
+$(document).on('input','#b_diagnostico',cargarTablaDiagnostico);
+$(document).on('change','#estado_filtro, #f_desde, #f_hasta',cargarTablaDiagnostico);
+$(document).on('click','#limpiar_busqueda_btn',function(){
+  $('#b_diagnostico').val('');
+  $('#estado_filtro').val('');
+  $('#f_desde').val('');
+  $('#f_hasta').val('');
+  cargarTablaDiagnostico();
+});
 
 
 

--- a/vistas/util.js
+++ b/vistas/util.js
@@ -144,7 +144,7 @@ function badgeEstado(estado) {
   else if (est === 'DIAGNOSTICADO' || est === 'DIAGNOSTICADA') cls = 'text-bg-info';
   else if (est === 'CERRADA' || est === 'CERRADO' || est === 'EMITIDO' || est === 'EMITIDA') cls = 'text-bg-primary';
   else if (est === 'APROBADO' || est === 'APROBADA' || est === 'APROBADO' || est === 'APROBADA') cls = 'text-bg-success';
-  else if (est === 'ANULADO' || est === 'ANULADA' || est === 'INACTIVO') cls = 'text-bg-danger';
+  else if (est === 'ANULADO' || est === 'ANULADA' || est === 'INACTIVO' || est === 'RECHAZADO' || est === 'RECHAZADA') cls = 'text-bg-danger';
 
   return `<span class="badge ${cls}">${estado}</span>`;
 }


### PR DESCRIPTION
## Summary
- Allow searching, state filtering and date range filtering on diagnostics
- Show new diagnostic state options including Aprobado and Rechazado
- Display badge styling for the Rechazado state

## Testing
- `php -l controladores/diagnostico.php`
- `node --check vistas/diagnostico.js`
- `node --check vistas/util.js`


------
https://chatgpt.com/codex/tasks/task_e_689ce9b185dc8325b3bf040ae3263e9c