### PR TITLE
Evitar cédulas duplicadas de conductores

### DIFF
--- a/utcdp1.sql
+++ b/utcdp1.sql
@@ -470,7 +470,8 @@ ALTER TABLE `cliente`
 -- Indices de la tabla `conductor`
 --
 ALTER TABLE `conductor`
-  ADD PRIMARY KEY (`id_conductor`);
+  ADD PRIMARY KEY (`id_conductor`),
+  ADD UNIQUE KEY `cedula` (`cedula`);
 
 --
 -- Indices de la tabla `resenas`


### PR DESCRIPTION
## Resumen
- Asegura que el campo `cedula` de la tabla `conductor` sea único en el script SQL.

## Testing
- `php -l controladores/conductor.php`


------
https://chatgpt.com/codex/tasks/task_e_689d1a6455dc8325889b1a23a8d3b0ea