### PR TITLE
Fix diagnostico state and date filters

### DIFF
--- a/controladores/diagnostico.php
+++ b/controladores/diagnostico.php
@@ -33,10 +33,10 @@ if(isset($_POST['eliminar'])){
 if(isset($_POST['leer'])){
  $sql="SELECT d.id_diagnostico,d.id_recepcion,r.nombre_cliente,d.fecha_inicio,d.estado FROM diagnostico d JOIN recepcion r ON d.id_recepcion=r.id_recepcion WHERE 1=1";
  $p=[];
- if(!empty($_POST['buscar'])){$sql.=" AND CONCAT(d.id_diagnostico,d.id_recepcion,r.nombre_cliente,d.fecha_inicio,d.estado) LIKE :buscar";$p['buscar']='%'.$_POST['buscar'].'%';}
- if(!empty($_POST['estado'])){$sql.=" AND d.estado=:estado";$p['estado']=$_POST['estado'];}
- if(!empty($_POST['desde'])){$sql.=" AND DATE(d.fecha_inicio)>=:desde";$p['desde']=$_POST['desde'];}
- if(!empty($_POST['hasta'])){$sql.=" AND DATE(d.fecha_inicio)<=:hasta";$p['hasta']=$_POST['hasta'];}
+ if(!empty($_POST['buscar'])){$sql.=" AND CONCAT(d.id_diagnostico,d.id_recepcion,r.nombre_cliente,d.fecha_inicio,d.estado) LIKE :buscar";$p['buscar']='%'.trim($_POST['buscar']).'%';}
+ if(isset($_POST['estado']) && $_POST['estado']!==''){$sql.=" AND d.estado=:estado";$p['estado']=trim($_POST['estado']);}
+ if(!empty($_POST['desde'])){$sql.=" AND DATE(d.fecha_inicio)>=:desde";$p['desde']=trim($_POST['desde']);}
+ if(!empty($_POST['hasta'])){$sql.=" AND DATE(d.fecha_inicio)<=:hasta";$p['hasta']=trim($_POST['hasta']);}
  $sql.=" ORDER BY d.id_diagnostico DESC";
  $q=$cn->prepare($sql);
  $q->execute($p);echo $q->rowCount()?json_encode($q->fetchAll(PDO::FETCH_OBJ)):'0';

--- a/vistas/diagnostico.js
+++ b/vistas/diagnostico.js
@@ -363,13 +363,13 @@ window.imprimirDiagnostico = imprimirDiagnostico;
 
 
 function cargarTablaDiagnostico(){
-  const filtros={
-    leer:1,
-    buscar:$("#b_diagnostico").val(),
-    estado:$("#estado_filtro").val(),
-    desde:$("#f_desde").val(),
-    hasta:$("#f_hasta").val()
-  };
+  const filtros = $.param({
+    leer: 1,
+    buscar: $("#b_diagnostico").val() || "",
+    estado: $("#estado_filtro").val() || "",
+    desde: $("#f_desde").val() || "",
+    hasta: $("#f_hasta").val() || ""
+  });
   let datos=ejecutarAjax("controladores/diagnostico.php",filtros),$tb=$("#diagnostico_datos_tb");
   if(datos==="0"){$tb.html("NO HAY REGISTROS");$("#diagnostico_count").text(0);}else{let js=JSON.parse(datos);$tb.html('');js.forEach(it=>$tb.append(`<tr><td>${it.id_diagnostico}</td><td>${it.id_recepcion} - ${it.nombre_cliente}</td><td>${it.fecha_inicio}</td><td>${badgeEstado(it.estado)}</td><td><button class="btn btn-secondary btn-sm imprimir-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-printer"></i></button> <button class="btn btn-warning btn-sm editar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-pencil-square"></i></button> <button class="btn btn-danger btn-sm eliminar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-trash"></i></button></td></tr>`));$("#diagnostico_count").text(js.length);}}
 


### PR DESCRIPTION
## Summary
- Properly serialize diagnostico filters before Ajax call
- Trim server-side parameters to apply estado and date range filters

## Testing
- `node --check vistas/diagnostico.js && echo 'Syntax OK'`
- `php -l controladores/diagnostico.php`

------
https://chatgpt.com/codex/tasks/task_e_689d1b6490448325a4cca31e0206170f