### PR TITLE
Cambiar eliminación por anulación de diagnósticos

### DIFF
--- a/paginas/referenciales/diagnostico/listar.php
+++ b/paginas/referenciales/diagnostico/listar.php
@@ -40,6 +40,7 @@
             <option value="PENDIENTE">Pendiente</option>
             <option value="APROBADO">Aprobado</option>
             <option value="RECHAZADO">Rechazado</option>
+            <option value="ANULADO">Anulado</option>
           </select>
         </div>
 

--- a/vistas/diagnostico.js
+++ b/vistas/diagnostico.js
@@ -371,7 +371,7 @@ function cargarTablaDiagnostico(){
     hasta: $("#f_hasta").val() || ""
   });
   let datos=ejecutarAjax("controladores/diagnostico.php",filtros),$tb=$("#diagnostico_datos_tb");
-  if(datos==="0"){$tb.html("NO HAY REGISTROS");$("#diagnostico_count").text(0);}else{let js=JSON.parse(datos);$tb.html('');js.forEach(it=>$tb.append(`<tr><td>${it.id_diagnostico}</td><td>${it.id_recepcion} - ${it.nombre_cliente}</td><td>${it.fecha_inicio}</td><td>${badgeEstado(it.estado)}</td><td><button class="btn btn-secondary btn-sm imprimir-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-printer"></i></button> <button class="btn btn-warning btn-sm editar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-pencil-square"></i></button> <button class="btn btn-danger btn-sm eliminar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-trash"></i></button></td></tr>`));$("#diagnostico_count").text(js.length);}}
+  if(datos==="0"){$tb.html("NO HAY REGISTROS");$("#diagnostico_count").text(0);}else{let js=JSON.parse(datos);$tb.html('');js.forEach(it=>{let btn=`<button class="btn btn-secondary btn-sm imprimir-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-printer"></i></button>`;if((it.estado||'').toUpperCase()!=='ANULADO'){btn+=` <button class="btn btn-warning btn-sm editar-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-pencil-square"></i></button> <button class="btn btn-danger btn-sm anular-diagnostico" data-id="${it.id_diagnostico}"><i class="bi bi-x-circle"></i></button>`;}$tb.append(`<tr><td>${it.id_diagnostico}</td><td>${it.id_recepcion} - ${it.nombre_cliente}</td><td>${it.fecha_inicio}</td><td>${badgeEstado(it.estado)}</td><td>${btn}</td></tr>`);});$("#diagnostico_count").text(js.length);}}
 
 function cargarDiagnostico(id){
   // Cargar la vista de edición antes de establecer los datos para evitar
@@ -381,6 +381,7 @@ function cargarDiagnostico(id){
   let d=ejecutarAjax("controladores/diagnostico.php","leer_id="+id);
   if(d!=='0'){
     let j=JSON.parse(d);
+    if((j.estado||'').toUpperCase()==='ANULADO'){alert('Diagnóstico anulado, no se puede editar.');return;}
 
     // Obtener los detalles del diagnóstico ya guardados
     let det=ejecutarAjax("controladores/detalle_diagnostico.php","leer=1&id_diagnostico="+id);
@@ -407,7 +408,7 @@ function cargarDiagnostico(id){
   }
 }
 $(document).on("click",".editar-diagnostico",function(){cargarDiagnostico($(this).data('id'));});
-$(document).on("click",".eliminar-diagnostico",function(){if(confirm("¿Eliminar?")){ejecutarAjax("controladores/diagnostico.php","eliminar="+$(this).data('id'));cargarTablaDiagnostico();cargarPendientesDiagnostico();}});
+$(document).on("click",".anular-diagnostico",function(){if(confirm("¿Anular?")){ejecutarAjax("controladores/diagnostico.php","anular="+$(this).data('id'));cargarTablaDiagnostico();cargarPendientesDiagnostico();}});
 $(document).on("click",".imprimir-diagnostico",function(){imprimirDiagnostico($(this).data('id'));});
 $(document).on('input','#b_diagnostico',cargarTablaDiagnostico);
 $(document).on('change','#estado_filtro, #f_desde, #f_hasta',cargarTablaDiagnostico);

--- a/vistas/util.js
+++ b/vistas/util.js
@@ -142,6 +142,7 @@ function badgeEstado(estado) {
   let cls = 'text-bg-secondary'; // fallback (gris)
   if (est === 'PENDIENTE')                 cls = 'text-bg-warning text-dark';
   else if (est === 'DIAGNOSTICADO' || est === 'DIAGNOSTICADA') cls = 'text-bg-info';
+  else if (est === 'ANULADO' || est === 'ANULADA') cls = 'text-bg-danger';
 
 
   return `<span class="badge ${cls}">${estado}</span>`;


### PR DESCRIPTION
## Summary
- Reemplaza la acción de eliminar diagnósticos por anulación y actualiza el estado a ANULADO
- Oculta opciones de edición/anulación para diagnósticos anulados y añade filtro correspondiente
- Añade soporte visual para el estado ANULADO en las etiquetas de estado

## Testing
- `php -l controladores/diagnostico.php`
- `php -l paginas/referenciales/diagnostico/listar.php`
- `node --check vistas/diagnostico.js`
- `node --check vistas/util.js`


------
https://chatgpt.com/codex/tasks/task_e_689d264390d0832590babf3eb77bcd29