### PR TITLE
feat: actualizar cantidad y subtotal de producto repetido

### DIFF
--- a/vistas/orden_compra.js
+++ b/vistas/orden_compra.js
@@ -218,20 +218,23 @@ function agregarProductoExtra(){
   }
 
   let idProducto = parseInt($("#id_producto_lst").val());
-  if(detallesOC.some(d => d.id_producto === idProducto)){
-    mensaje_dialogo_info_ERROR("El producto ya está cargado","ERROR");
-    return;
+  let idx = detallesOC.findIndex(d => d.id_producto === idProducto);
+
+  if (idx !== -1) {
+    // Si el producto ya estaba cargado, sumar la cantidad y actualizar precio y subtotal
+    detallesOC[idx].cantidad += cantidad;
+    detallesOC[idx].precio_unitario = precio;
+    detallesOC[idx].subtotal = detallesOC[idx].cantidad * precio;
+  } else {
+    let detalle = {
+      id_producto: idProducto,
+      producto: $("#id_producto_lst option:selected").text(),
+      cantidad: cantidad,
+      precio_unitario: precio, // numérico sin puntos
+      subtotal: cantidad * precio
+    };
+    detallesOC.push(detalle);
   }
-
-  let detalle = {
-    id_producto: idProducto,
-    producto: $("#id_producto_lst option:selected").text(),
-    cantidad: cantidad,
-    precio_unitario: precio, // numérico sin puntos
-    subtotal: cantidad * precio
-  };
-
-  detallesOC.push(detalle);
   renderDetallesOC();
   calcularTotalOrdenLocal();
   limpiarDetalleExtraForm(true); // aquí sí enfocamos cantidad para seguir cargando


### PR DESCRIPTION
## Summary
- Al agregar un producto ya cargado en la orden de compra, acumula la cantidad, actualiza el precio unitario y recalcula el subtotal

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e0b7142e88325acb42491ec11aee1