### PR TITLE
Fix credit note state filter to include ACTIVO

### DIFF
--- a/controladores/nota_credito.php
+++ b/controladores/nota_credito.php
@@ -112,7 +112,7 @@ if (isset($_POST['leer_descripcion'])) {
 
     if ($estado !== '') {
         // limitar a valores válidos
-        if (!in_array($estado, ['EMITIDO','ANULADO'], true)) { echo json_encode([]); exit; }
+        if (!in_array($estado, ['ACTIVO','ANULADO'], true)) { echo json_encode([]); exit; }
         $sql .= " AND n.estado = :estado";
         $params['estado'] = $estado;
     }


### PR DESCRIPTION
## Summary
- allow credit note search to validate ACTIVO or ANULADO

## Testing
- `php -l controladores/nota_credito.php`


------
https://chatgpt.com/codex/tasks/task_e_689e0d1c9df083259ebe9bb4ed1d6450