### PR TITLE
Load dashboard with real data and remove unused chart

### DIFF
--- a/controladores/dashboard.php
+++ b/controladores/dashboard.php
@@ -1,0 +1,70 @@
+<?php
+require_once '../conexion/db.php';
+
+if(isset($_POST['dashboard'])){
+    $db = new DB();
+    $cn = $db->conectar();
+
+    $totales = [
+        'proveedores' => (int)$cn->query("SELECT COUNT(*) FROM proveedor")->fetchColumn(),
+        'clientes' => (int)$cn->query("SELECT COUNT(*) FROM clientes")->fetchColumn(),
+        'presupuestos' => (int)$cn->query("SELECT COUNT(*) FROM presupuestos_compra")->fetchColumn(),
+        'ordenes' => (int)$cn->query("SELECT COUNT(*) FROM orden_compra")->fetchColumn(),
+        'remisiones' => (int)$cn->query("SELECT COUNT(*) FROM remision")->fetchColumn(),
+        'notas' => (int)$cn->query("SELECT COUNT(*) FROM nota_credito")->fetchColumn()
+    ];
+
+    // Compras y ventas por mes
+    $mesesNombres = [1=>'Ene',2=>'Feb',3=>'Mar',4=>'Abr',5=>'May',6=>'Jun',7=>'Jul',8=>'Ago',9=>'Sep',10=>'Oct',11=>'Nov',12=>'Dic'];
+    $comprasData = [];
+    $ventasData = [];
+    $meses = [];
+
+    $stmt = $cn->query("SELECT MONTH(fecha_emision) AS mes, COUNT(*) AS total FROM orden_compra GROUP BY mes");
+    while($row = $stmt->fetch(PDO::FETCH_ASSOC)){
+        $mes = (int)$row['mes'];
+        $meses[$mes] = true;
+        $comprasData[$mes] = (int)$row['total'];
+    }
+
+    $stmt = $cn->query("SELECT MONTH(fecha_recepcion) AS mes, COUNT(*) AS total FROM recepcion GROUP BY mes");
+    while($row = $stmt->fetch(PDO::FETCH_ASSOC)){
+        $mes = (int)$row['mes'];
+        $meses[$mes] = true;
+        $ventasData[$mes] = (int)$row['total'];
+    }
+
+    $meses = array_keys($meses);
+    sort($meses);
+    $mesesLabels = array_map(function($m) use ($mesesNombres){ return $mesesNombres[$m]; }, $meses);
+
+    $seriesCompras = [];
+    $seriesVentas = [];
+    foreach($meses as $m){
+        $seriesCompras[] = $comprasData[$m] ?? 0;
+        $seriesVentas[] = $ventasData[$m] ?? 0;
+    }
+
+    // Órdenes de compra por estado
+    $labels = [];
+    $series = [];
+    $stmt = $cn->query("SELECT estado, COUNT(*) AS total FROM orden_compra GROUP BY estado");
+    while($row = $stmt->fetch(PDO::FETCH_ASSOC)){
+        $labels[] = $row['estado'];
+        $series[] = (int)$row['total'];
+    }
+
+    echo json_encode([
+        'totales' => $totales,
+        'compras_ventas' => [
+            'meses' => $mesesLabels,
+            'compras' => $seriesCompras,
+            'ventas' => $seriesVentas
+        ],
+        'ordenes_estado' => [
+            'labels' => $labels,
+            'series' => $series
+        ]
+    ]);
+}
+?>

--- a/paginas/dashboard.php
+++ b/paginas/dashboard.php
@@ -8,7 +8,7 @@
             <i class="bi bi-truck fs-1 me-3"></i>
             <div>
               <h6 class="card-title mb-0">Proveedores</h6>
-              <p class="fs-4 mb-0">0</p>
+              <p class="fs-4 mb-0" id="total_proveedores">0</p>
             </div>
           </div>
         </div>
@@ -21,7 +21,7 @@
             <i class="bi bi-people fs-1 me-3"></i>
             <div>
               <h6 class="card-title mb-0">Clientes</h6>
-              <p class="fs-4 mb-0">0</p>
+              <p class="fs-4 mb-0" id="total_clientes">0</p>
             </div>
           </div>
         </div>
@@ -34,7 +34,7 @@
             <i class="bi bi-clipboard-data fs-1 me-3"></i>
             <div>
               <h6 class="card-title mb-0">Presupuestos</h6>
-              <p class="fs-4 mb-0">0</p>
+              <p class="fs-4 mb-0" id="total_presupuestos">0</p>
             </div>
           </div>
         </div>
@@ -47,7 +47,7 @@
             <i class="bi bi-receipt fs-1 me-3"></i>
             <div>
               <h6 class="card-title mb-0">Órdenes de Compra</h6>
-              <p class="fs-4 mb-0">0</p>
+              <p class="fs-4 mb-0" id="total_ordenes">0</p>
             </div>
           </div>
         </div>
@@ -60,7 +60,7 @@
             <i class="bi bi-truck-front fs-1 me-3"></i>
             <div>
               <h6 class="card-title mb-0">Remisiones</h6>
-              <p class="fs-4 mb-0">0</p>
+              <p class="fs-4 mb-0" id="total_remisiones">0</p>
             </div>
           </div>
         </div>
@@ -73,7 +73,7 @@
             <i class="bi bi-file-earmark-minus fs-1 me-3"></i>
             <div>
               <h6 class="card-title mb-0">Notas de Crédito</h6>
-              <p class="fs-4 mb-0">0</p>
+              <p class="fs-4 mb-0" id="total_notas">0</p>
             </div>
           </div>
         </div>
@@ -96,15 +96,6 @@
       </div>
     </div>
   </div>
-  <div class="row g-3 mb-4">
-    <div class="col-lg-12">
-      <div class="card">
-        <div class="card-header">Servicios abiertos por tipo</div>
-        <div class="card-body"><div id="chart-servicios"></div></div>
-      </div>
-    </div>
-  </div>
-
   <!-- Tables -->
   <div class="row g-3 mb-4">
     <div class="col-lg-4">
@@ -171,32 +162,3 @@
   </div>
 </div>
 
-<script>
-  var opcionesBarra = {
-    chart: {type: 'bar', height: 300},
-    series: [
-      {name: 'Compras', data: [10,20,15,30,25,35]},
-      {name: 'Ventas', data: [5,15,10,25,20,30]}
-    ],
-    xaxis: {categories: ['Ene','Feb','Mar','Abr','May','Jun']}
-  };
-  var chart1 = new ApexCharts(document.querySelector('#chart-compras-ventas'), opcionesBarra);
-  chart1.render();
-
-  var opcionesPie = {
-    chart: {type: 'pie', height: 300},
-    series: [44,33,23],
-    labels: ['Pendiente','Aprobado','Anulado']
-  };
-  var chart2 = new ApexCharts(document.querySelector('#chart-ordenes-estado'), opcionesPie);
-  chart2.render();
-
-  var opcionesHBar = {
-    chart: {type: 'bar', height: 300},
-    plotOptions: {bar: {horizontal: true}},
-    series: [{data: [5,3,4]}],
-    xaxis: {categories: ['Cliente A','Cliente B','Cliente C']}
-  };
-  var chart3 = new ApexCharts(document.querySelector('#chart-servicios'), opcionesHBar);
-  chart3.render();
-</script>

--- a/vistas/dashboard.js
+++ b/vistas/dashboard.js
@@ -1,4 +1,37 @@
 function mostrarDashboard(){
     const contenido = dameContenido("paginas/dashboard.php");
     $("#contenido-principal").html(contenido);
+    cargarDatosDashboard();
+}
+
+function cargarDatosDashboard(){
+    $.post("controladores/dashboard.php", {dashboard: true}, function(resp){
+        const data = JSON.parse(resp);
+
+        $("#total_proveedores").text(data.totales.proveedores);
+        $("#total_clientes").text(data.totales.clientes);
+        $("#total_presupuestos").text(data.totales.presupuestos);
+        $("#total_ordenes").text(data.totales.ordenes);
+        $("#total_remisiones").text(data.totales.remisiones);
+        $("#total_notas").text(data.totales.notas);
+
+        var opcionesBarra = {
+            chart: {type: 'bar', height: 300},
+            series: [
+                {name: 'Compras', data: data.compras_ventas.compras},
+                {name: 'Ventas', data: data.compras_ventas.ventas}
+            ],
+            xaxis: {categories: data.compras_ventas.meses}
+        };
+        var chart1 = new ApexCharts(document.querySelector('#chart-compras-ventas'), opcionesBarra);
+        chart1.render();
+
+        var opcionesPie = {
+            chart: {type: 'pie', height: 300},
+            series: data.ordenes_estado.series,
+            labels: data.ordenes_estado.labels
+        };
+        var chart2 = new ApexCharts(document.querySelector('#chart-ordenes-estado'), opcionesPie);
+        chart2.render();
+    });
 }


### PR DESCRIPTION
## Summary
- Populate dashboard cards and charts with live data from the database
- Remove unused "Servicios abiertos por tipo" section

## Testing
- `php -l paginas/dashboard.php`
- `php -l controladores/dashboard.php`
- `node --check vistas/dashboard.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_689e1891432483259ab174ec4c54a530