### PR TITLE
Mostrar últimos datos en dashboard

### DIFF
--- a/controladores/dashboard.php
+++ b/controladores/dashboard.php
@@ -54,6 +54,29 @@ if(isset($_POST['dashboard'])){
         $series[] = (int)$row['total'];
     }
 
+    // Últimos registros
+    $ultimosPresupuestos = $cn->query(
+        "SELECT p.fecha, pr.razon_social AS proveedor, p.total_estimado AS monto, p.estado
+         FROM presupuestos_compra p
+         LEFT JOIN proveedor pr ON p.id_proveedor = pr.id_proveedor
+         ORDER BY p.id_presupuesto DESC LIMIT 5"
+    )->fetchAll(PDO::FETCH_ASSOC);
+
+    $ultimasOrdenes = $cn->query(
+        "SELECT o.fecha_emision AS fecha, o.id_orden, pr.razon_social AS proveedor, o.estado
+         FROM orden_compra o
+         LEFT JOIN proveedor pr ON o.id_proveedor = pr.id_proveedor
+         ORDER BY o.id_orden DESC LIMIT 5"
+    )->fetchAll(PDO::FETCH_ASSOC);
+
+    $ultimasRecepciones = $cn->query(
+        "SELECT r.fecha_recepcion AS fecha, r.nombre_cliente AS cliente, IFNULL(COUNT(d.id_detalle),0) AS equipos, r.estado
+         FROM recepcion r
+         LEFT JOIN recepcion_detalle d ON r.id_recepcion = d.id_recepcion
+         GROUP BY r.id_recepcion, r.fecha_recepcion, r.nombre_cliente, r.estado
+         ORDER BY r.id_recepcion DESC LIMIT 5"
+    )->fetchAll(PDO::FETCH_ASSOC);
+
     echo json_encode([
         'totales' => $totales,
         'compras_ventas' => [
@@ -64,7 +87,10 @@ if(isset($_POST['dashboard'])){
         'ordenes_estado' => [
             'labels' => $labels,
             'series' => $series
-        ]
+        ],
+        'ultimos_presupuestos' => $ultimosPresupuestos,
+        'ultimas_ordenes' => $ultimasOrdenes,
+        'ultimas_recepciones' => $ultimasRecepciones
     ]);
 }
 ?>

--- a/paginas/dashboard.php
+++ b/paginas/dashboard.php
@@ -105,7 +105,7 @@
           <div class="table-responsive" style="max-height:200px;">
             <table class="table mb-0">
               <thead><tr><th>Fecha</th><th>Proveedor</th><th>Monto</th><th>Estado</th></tr></thead>
-              <tbody>
+              <tbody id="tbody_presupuestos">
                 <tr><td>-</td><td>-</td><td>-</td><td>-</td></tr>
               </tbody>
             </table>
@@ -120,7 +120,7 @@
           <div class="table-responsive" style="max-height:200px;">
             <table class="table mb-0">
               <thead><tr><th>Fecha</th><th>Nro</th><th>Proveedor</th><th>Estado</th></tr></thead>
-              <tbody>
+              <tbody id="tbody_ordenes">
                 <tr><td>-</td><td>-</td><td>-</td><td>-</td></tr>
               </tbody>
             </table>
@@ -135,7 +135,7 @@
           <div class="table-responsive" style="max-height:200px;">
             <table class="table mb-0">
               <thead><tr><th>Fecha</th><th>Cliente</th><th>Equipo</th><th>Estado</th></tr></thead>
-              <tbody>
+              <tbody id="tbody_recepciones">
                 <tr><td>-</td><td>-</td><td>-</td><td>-</td></tr>
               </tbody>
             </table>

--- a/vistas/dashboard.js
+++ b/vistas/dashboard.js
@@ -33,5 +33,21 @@ function cargarDatosDashboard(){
         };
         var chart2 = new ApexCharts(document.querySelector('#chart-ordenes-estado'), opcionesPie);
         chart2.render();
+
+        rellenarTabla('#tbody_presupuestos', data.ultimos_presupuestos, ['fecha','proveedor','monto','estado']);
+        rellenarTabla('#tbody_ordenes', data.ultimas_ordenes, ['fecha','id_orden','proveedor','estado']);
+        rellenarTabla('#tbody_recepciones', data.ultimas_recepciones, ['fecha','cliente','equipos','estado']);
     });
+}
+
+function rellenarTabla(selector, datos, campos){
+    const tbody = $(selector).empty();
+    if (datos.length){
+        datos.forEach(d => {
+            const cols = campos.map(c => `<td>${d[c] ?? ''}</td>`).join('');
+            tbody.append(`<tr>${cols}</tr>`);
+        });
+    } else {
+        tbody.append(`<tr><td colspan="${campos.length}">-</td></tr>`);
+    }
 }


### PR DESCRIPTION
## Summary
- Recuperar y enviar desde el controlador los últimos presupuestos, órdenes y recepciones.
- Agregar identificadores a las tablas del dashboard y rellenarlas dinámicamente desde JavaScript.

## Testing
- `php -l controladores/dashboard.php`
- `php -l paginas/dashboard.php`
- `node --check vistas/dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_689e1a2c2ba48325b4d1148655b1483b